### PR TITLE
Other: Add support for disabling Aero Snap Quadrants on Windows 11

### DIFF
--- a/ExplorerPatcher/settings.reg
+++ b/ExplorerPatcher/settings.reg
@@ -537,6 +537,9 @@
 ;x 4 Restart
 "Start_PowerButtonAction"=dword:00000002
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
+;b Disable Window Snap Quadrants
+"DisableAeroSnapQuadrants"=dword:00000000
+[HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;c 2 Snap Assist style
 ;x 0 Windows 11 (default)
 ;x 3 Windows 10


### PR DESCRIPTION
## Overview

This pull request implements support for disabling Aero Snap quadrants in Windows 11 (titled "Windows Snap Quadrants" for ExplorerPatcher). Originally when Aero Snap was introduced in Windows 7, Aero Snap allowed for a simple 1x2 window configuration (i.e. windows may be snapped to either the left or right hand side of the screen). In Windows 10 however, the concept of snap "quadrants" was introduced, allowing windows to additionally be snapped to the *corners* of a screen, allowing for a 2x2 configuration, potentially useful if you have an extremely large monitor.

For my case, with a simple 1080p monitor, corner snapping is *never* desirable, and yet when I drag and fling a titlebar over to the side of my screen more often than not I inadvertently corner snap rather than side snap, requiring me to stop and re-snap the window properly. This pull request allows corner regions to be completely disabled, restoring the original Windows 7 behavior.

## Tracing Aero Snap

The implementation details of Aero Snap were ascertained by attempting to perform an analysis of what happens when you press Windows Key + Right Arrow in Windows 10, and then later Windows 11. Through the course of this analysis it became apparent that the way Aero Snap is implemented in Windows 10 is completely different to the way it is implemented in Windows 11 (and it was a big mistake assuming Windows 10 and 11 would more or less have the same symbols). Regardless, the following describes the key parts of how Windows + Left/Right arrow key works in Windows 11:

1. In the kernel, historically, a function `ProcessKeyboardInput` is registered with a pnp driver, that calls `win32kbase!xxxProcessKeyEvent` -> `xxxKeyEvent` whenever it receives some keyboard input. From here, the keyboard input is dispatched to `win32kfull!xxxDoHotKeyStuff`, followed by `PostRawKeyboardInput`
    * "Hotkey Stuff" is handled prior to handling regular keyboard input (you can't intercept the secure attention sequence if you never got a chance!)
    * The implementation details surrounding this have changed a bit in recent Windows versions, however this is generally a good starting point for anyone interested in looking at how the keyboard works
3. `win32kfull!xxxDoHotKeyStuff` has special logic to detect when a window arrangement hotkey has been pressed. Ultimately, someone will dispatch a special window message `0x342` that will be the key to finding where the hotkey goes
4. At some point `wink32full!xxxSendMessageCallback` is called with window message `0x342`, however after deferring to `win32kfull!xxxInterSendMsgEx` I believe the message is eventually posted and we lose track of the trail. Luckily however, we can guess where it ends up: `win32kfull!xxxReceiveMessage`, where `win32kfull!xxxSendMessageToClient` is later called. This is a critical location in the reverse engineering of the hotkey. The only issue we have now is breaking at the point in time when the posted message is eventually received. By setting a conditional breakpoint on calls to `win32kfull!xxxSendMessageToClient` where `rdx == 0x342` we can filter out the noise from all the other reasons this function is called, and progress finding where the message goes.

    Note that while a `PWND` is passed to `xxxSendMessageCallback`, this is a false lead: `!handle` told me this `PWND` belonged to csrss, but in the end it was Explorer that received the message
6. Ultimately, we end up at a function pointer `win32kfull_SfnSHELLWINDOWMANAGEMENTNOTIFY`
7. After a `KeUserModeCallback`, we wind up on the other side in `user32!_fnSHELLWINDOWMANAGEMENTNOTIFY`, indicating to me that secret message `0x342` is actually called `WM_MANAGEMENTNOTIFY` or something to that effect

    Fun fact: while WinDbg doesn't seem to be able to step "into" a `sysret` (or at least I don't know how to do it), I found a clever way around this by having a look at the index specified in `rdx` before the `sysret` happens. This tells us the index in the `KernelCallbackTable` in the current PEB to look at. By utilizing the information found in this table, we can simply set a hardware breakpoint and continue, letting the debugger take care of switching our context for us

    ```
    //First, dump the peb
    dt nt!_PEB @$peb

    //In the output, find the address of the KernelCallbackTable, then dump it. While you can technically dt for that field
    //immediately, doing so seemed to give me a different address. YMMV
    dqs 0x00007fff`6f175000 L54

    //Now scroll down, find the function listed for the index in rdx, and set a breakpoint on it!
    ba e 1 user32!fnSHELLWINDOWMANAGEMENTNOTIFY
    ```
8. From here, we're disaptched to `twinui!CWRLImpWndProc<WindowManagementEvents>::s_WndProcBase`
9. Then `WindowManagementEvents::OnShellWindowManagementNotify`
10. And then finally `twinui_pcshell!CShellSnapComponent::OnHotkey`
11. Stepping through this method, we're able to see that when snapping a window a "snap quadrants policy" is checked to determine how the resizing of the window should be handled (`twinui_pcshell!SnapLayoutHelpers::AreQuadrantsEnabled`). According to this method, snap quadrants are disabled either when the computer is in tablet mode, or some global variable is set. As such, attempting to influence the value of this global variable is our best bet for overriding this policy
12. The snap quadrants global variable is initialized via `twinui_pcshell!SnapLayoutHelpers::InitializeSnapQuadrantsPolicy`
13. This in turn calls a method `winrt::impl::consume_WindowsUdk_UI_Shell_ISnapLayoutManager<winrt::WindowsUdk::UI::Shell::ISnapLayoutManager>::MaximumSnappedWindowsPolicy` which defers to a getter in `windowsudk.shellcommon.dll` - `get_MaximumSnappedWindowsPolicy` on some WinRT class
14. Stepping through this getter, ultimately we end up at our final destination `winrt::make<winrt::WindowsUdk::UI::Shell::implementation::SnapLayoutManager,winrt::Windows::UI::WindowManagement::DisplayRegion const &>`

## Implementation Details

The goal of the `WindowManagement::DisplayRegion` method is to ascertain the number of snappable regions that should be displayed on the screen. The way it does this is by looking up special licensing policy setting `Shell-Windowing-LimitSnappedWindows` via the [SLGetWindowsInformationDWORD](https://docs.microsoft.com/en-us/windows/win32/api/slpublic/nf-slpublic-slgetwindowsinformationdword) function. If the query for this license policy returns 1, the number of snappable regions are limited to a 1x2 division; otherwise, a 2x2 division is used.

`SLGetWindowsInformationDWORD` gets its information from the registry key `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\ProductOptions`, value `ProductPolicy`

* [Additional Information about the ProductPolicy value](https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ex/slmem/productpolicy.htm)

While there are programs our there that are technically capable of reading and modifying the values stored in this key, this is apparently [not a good idea](https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ex/slmem/gettamperstate.htm) as doing so may blue screen your system. As a result, we need to resort to somehow detouring this function.

The implementation that has been used in ExplorerPatcher is to install a simple IAT hook on windowsudk.shellcommon's `SLGetWindowsInformationDWORD` import. This allows us to change the `Shell-Windowing-LimitSnappedWindows` license value into a `1` when `windowsudk.shellcommon` queries it during Explorer startup.

## Additional Details

After Explorer has initialized its quadrants policy, it appears to IPC this information to another process (possibly `sihost.exe`?) thereby allowing Aero Snap to still work using the mouse even if Explorer is manually killed (albeit, only using the mouse).

It is hard to say which process it is that handles Aero Snap in lieu of Explorer, as DWM is mandatory in newer Windows versions, however I can say that at the very least in Windows 7 Aero Snap still works even if you kill DWM and Explorer. While this does not affect the implementation of this feature, it is important to understand when considering *why* the same snapping policy persists after Explorer is terminated. Note that upon Explorer restarting with a new snapping policy, it will IPC the new policy to this mysterious "other process", thereby overwriting the old policy and activating the new one

Note that, as mentioned above, the implementation of Aero Snap Quadrants in Windows 10 appears to be completely different compared to Windows 11 (symbols that include the word *snap* or *quadrant* are almost nowhere to be seen, which is what led me on my journey through the kernel in the first place). As such this feature as currently implemented is only for Windows 11