### PR TITLE
File Explorer: Add support for classic drive groupings in This PC

### DIFF
--- a/ExplorerPatcher/ExplorerPatcher.rc
+++ b/ExplorerPatcher/ExplorerPatcher.rc
@@ -111,6 +111,12 @@ BEGIN
     IDS_INSTALL_SUCCESS_TEXT "Installation succeeded."
     IDS_INSTALL_ERROR_TEXT  "Installation failed."
     IDS_UNINSTALL_SUCCESS_TEXT "Uninstallation succeeded."
+    IDS_DRIVECATEGORY_HARDDISKDRIVES      "Hard Disk Drives"
+    IDS_DRIVECATEGORY_REMOVABLESTORAGE    "Devices with Removable Storage"
+    IDS_DRIVECATEGORY_OTHER               "Other"
+    IDS_DRIVECATEGORY_IMAGING             "Scanners and Cameras"
+    IDS_DRIVECATEGORY_PORTABLEMEDIADEVICE "Portable Media Devices"
+    IDS_DRIVECATEGORY_PORTABLEDEVICE      "Portable Devices"
 END
 
 STRINGTABLE

--- a/ExplorerPatcher/resource.h
+++ b/ExplorerPatcher/resource.h
@@ -16,6 +16,13 @@
 #define IDS_UNINSTALL_ERROR_TEXT        112
 #define IDS_OPERATION_NONE              113
 #define IDR_REGISTRY2                   114
+#define IDS_DRIVECATEGORY_HARDDISKDRIVES              40000
+#define IDS_DRIVECATEGORY_REMOVABLESTORAGE            40001
+#define IDS_DRIVECATEGORY_OTHER                       40002
+#define IDS_DRIVECATEGORY_IMAGING                     40003
+#define IDS_DRIVECATEGORY_PORTABLEMEDIA               40004
+#define IDS_DRIVECATEGORY_PORTABLEMEDIADEVICE         40004
+#define IDS_DRIVECATEGORY_PORTABLEDEVICE              40005
 
 // Next default values for new objects
 // 

--- a/ExplorerPatcher/settings.reg
+++ b/ExplorerPatcher/settings.reg
@@ -164,6 +164,9 @@
 [-HKEY_CURRENT_USER\Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32]
 ;d Disable the Windows 11 context menu *
 @=""
+[HKEY_CURRENT_USER\Software\ExplorerPatcher]
+;b Use classic drive groupings in This PC *
+"UseClassicDriveGrouping"=dword:00000000
 ;t The following settings take effect on newly created File Explorer windows:
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;i Use immersive menus when displaying Windows 10 context menus **

--- a/ExplorerPatcher/settings10.reg
+++ b/ExplorerPatcher/settings10.reg
@@ -142,6 +142,9 @@
 ;https://github.com/valinet/ExplorerPatcher/wiki/Using-ExplorerPatcher-as-shell-extension
 ;q
 [HKEY_CURRENT_USER\Software\ExplorerPatcher]
+;b Use classic drive groupings in This PC *
+"UseClassicDriveGrouping"=dword:00000000
+[HKEY_CURRENT_USER\Software\ExplorerPatcher]
 ;i Use immersive menus when displaying Windows 10 context menus **
 "DisableImmersiveContextMenu"=dword:00000000
 [-HKEY_CURRENT_USER\Software\Classes\CLSID\{056440FD-8568-48e7-A632-72157243B55B}\InprocServer32]


### PR DESCRIPTION
## Overview

In modern versions of Windows the separation between many types of devices under *This PC* is removed. Devices with removable storage, built-in hard drives and portable devices such as phones and tablets are all lumped together under one big banner of "Devices and drives".

This pull request restores the "classic" drive groupings seen in Windows 7, wherein devices and drives are more coherently separated into various groups: "Hard Disk Drives", "Devices with Removable Storage", "Portable Devices", etc. It does this by replacing the default [ICategorizer](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-icategorizer) that is used by Windows when *This PC* is opened.

## Implementation Details

### Background

When `shell32!DllGetClassObject` is called with `CLSID_DriveTypeCategorizer` it ostensibly returns an `IClassFactory` that can be used for creating `ICategorizer` instances. In fact, the way shell32 handles its class factories is it has a big list consisting of *class factory entries*, with entry containing
* the common `IClassFactoryVtbl` shared by all class factory entries
* various flags
* the CLSID of this particular entry
* **a function pointer pointing to the *real* `CreateInstance` function that should be used to create an instance for this particular factory**

When `IClassFactory::CreateInstance` is called (`shell32!ECFCreateInstance`), the `IClassFactory*` value passed to it is casted back into a `FactoryEntry*` and the `pfnCreateInstance` member on it is invoked to actually create an instance (`shell32!CDriveTypeCategorizer_CreateInstance`).

### Hooking

As a result of the fact all `IClassFactory` objects returned by `shell32!DllGetClassObject` technically share the same `IClassFactoryVtbl`, hooking the `IClassFactory::CreateInstance` function directly would implicitly mean that anyone that calls `shell32!DllGetClassObject` with *any* CLSID will get an `IClassFactory` whose `CreateInstance` points to our hook. While we can always simply defer to the original `CreateInstance` (`shell32!ECFCreateInstance`) in our hook if the `CreateInstance` request isn't for the `IID` we want (`IID_ICategorizer`), for efficiency (at the potential risk of brittleness) I have opted to instead cast the `IClassFactory*` into its true `FactoryEntry*` form so we can then hook *just* calls to `shell32!CDriveTypeCategorizer_CreateInstance`.

### Categorizer

In order to implement a custom categorizer we need to write a COM object that implements both the `ICategorizer` and `IShellExtInit` interfaces. The fact that ExplorerPatcher is a pure C project posed some major challenges for achieving this: there is almost no information about writing COM objects in plain C on the internet (for good reason!), and there is *absolutely no* information I could find about writing COM objects in C that implement *multiple interfaces*. As a result, I did my best to implement my COM object (`EPCategorizer`) in a way that I think makes sense based on my research. Things like [adjustor thunks](https://devblogs.microsoft.com/oldnewthing/20040206-00/?p=40723) that would normally be handled by the compiler I am assuming I have to write manually, so I did.

The way categorization works is that each item under *This PC* is assigned a `SHDID_` enumeration type (i.e. `SHDID_COMPUTER_FIXED`, `SHDID_COMPUTER_REMOVABLE`, `SHDID_MOBILE_DEVICE`, etc). For each item a *category ID* needs to be assigned. Rather than assigning an arbitrary value for these category IDs, shell32 takes a smart approach: it uses the *DLL resource ID of the category name as the category ID*. As a result, when these category IDs are passed to functions like [ICategorizer::GetCategoryInfo](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-icategorizer-getcategoryinfo) where you're expected to fill in the category name, all you need to do is treat the `dwCategoryId` as a resource ID and look it up in your DLL. Decisions about what order the categories should be listed in are also easy: the resource IDs are numbered in the order they should display in. Problem solved!

While this strategy works well for shell32, for our purposes not *all* of the categories in shell32 need overriding, so we take a different approach: we define ExplorerPatcher's custom resource IDs starting from a very high number nowhere near what shell32 uses, and then determine the order with which categories should be listed based on their position in a mapping array, thereby giving us full control of how things should be ordered.

## Comments

* It's hard to say whether it's better to hook the `IClassFactory::CreateInstance` method directly, or be tricky and hook the reference to the *real* create instance method `CDriveTypeCategorizer_CreateInstance` directly. All things being considered I think the way I've done it (the latter approach) is *probably* the preferred way to go
* There are many other potential ways the custom `ICategorizer` implementation could be done; as mentioned, writing a COM object that implements two interfaces in plain C was very difficult - there's a lot of pointer craziness to think about. Other potential implementation strategies here such as hooking all of the methods on shell32's default `ICategorizer` I don't think are appropriate for several reasons
* Given every call to `ICategorizer::GetDescription` loads a resource in shell32, I have stored a handle to shell32 globally, which I think makes more sense than getting a handle every time the method is called
* The implementation of `driveCategoryMap` is pretty efficient to manage IMO, and I later discovered it seems shell32 declares its own internal map in the exact same way, which is more or less a tick of approval for the way I'd decided to do it