### PR TITLE
Fix "UWP Apps" occurrence in Win10 Start Menu

### DIFF
--- a/version.h
+++ b/version.h
@@ -1,6 +1,6 @@
 #define VER_MAJOR 22621
-#define VER_MINOR 1555
-#define VER_BUILD_HI    55
+#define VER_MINOR 1992
+#define VER_BUILD_HI    92
 #define VER_BUILD_LO 2
 #define VER_FLAGS   VS_FF_PRERELEASE
 
@@ -12,5 +12,5 @@
 #define VER_STR(arg) #arg
 
 // The String form of the version numbers
-#define VER_FILE_STRING VALUE "FileVersion", "22621.1555.55.2"
-#define VER_PRODUCT_STRING VALUE "ProductVersion", "22621.1555.55.2"
+#define VER_FILE_STRING VALUE "FileVersion", "22621.1992.55.1"
+#define VER_PRODUCT_STRING VALUE "ProductVersion", "22621.1992.55.1"


### PR DESCRIPTION
I've looked at ways to fix this issue but I've only found this method better than others. For the fix, I've used win32 Dll's in this method. So, lets look for fix.

Just navigate to `C:\Windows\SystemApps\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy` and rename the **AppResolverLegacy** and **StartTileDataLegacy** to anything. (just add 0 t0 last of dll i.e. dll0)
Now, copy the **AppResolver and StartTileData** from win32 directory (i.e. system32)
Place them in the Step1 directory and add **Legacy** to the end of their names. (like old one have)
Now restart the explorer.
It will fix all the issues with Win10 Start Menu. But, there is a bug that "`Pin to Start`" won't work. But, there is also a workaround for this problem :
**Pinning an App** : Just Drag&Drop the App to the Tile Area
**Unpinning an App** : Drag the app tile to new group and ungroup that group.

Now, the only bug remains after this method is to fix `pin to start` button.

It will be more easy to users if you add this as an option in EP settings, so that people don't want to do this messy thing with their dll's. You can simply add this with a warning or disclaimer regarding "Pin to Start" bug, till you find the full fix or able to fix the broken button.