### PR TITLE
Ability to restore Win10 JumpViewUI with a bug fix

### DIFF
--- a/version.h
+++ b/version.h
@@ -1,7 +1,7 @@
 #define VER_MAJOR 22621
-#define VER_MINOR 1992
+#define VER_MINOR 2134
 #define VER_BUILD_HI    56
-#define VER_BUILD_LO 1
+#define VER_BUILD_LO 3
 #define VER_FLAGS   VS_FF_PRERELEASE
 
 
@@ -12,5 +12,5 @@
 #define VER_STR(arg) #arg
 
 // The String form of the version numbers
-#define VER_FILE_STRING VALUE "FileVersion", "22621.1992.55.2"
-#define VER_PRODUCT_STRING VALUE "ProductVersion", "22621.1992.55.2"
+#define VER_FILE_STRING VALUE "FileVersion", "22621.2134.56.3"
+#define VER_PRODUCT_STRING VALUE "ProductVersion", "22621.2134.56.3"

--- a/version.h
+++ b/version.h
@@ -12,5 +12,5 @@
 #define VER_STR(arg) #arg
 
 // The String form of the version numbers
-#define VER_FILE_STRING VALUE "FileVersion", "22621.1992.56.1"
-#define VER_PRODUCT_STRING VALUE "ProductVersion", "22621.1992.56.1"
+#define VER_FILE_STRING VALUE "FileVersion", "22621.1992.55.2"
+#define VER_PRODUCT_STRING VALUE "ProductVersion", "22621.1992.55.2"


### PR DESCRIPTION
1. Can EP restore the Windows 10 JumpViewUI for Win10 Taskbar. As it can be done in 22000.1 and works perfectly, but it breaks Action Center (and Notification center too)

`C:\Windows\ShellExperiences\JumpViewUI.dll`
`C:\Windows\SystemResources\Windows.UI.ShellCommon\Windows.UI.ShellCommon.pri`

Thanks [@bbmaster123](https://github.com/bbmaster123/10SM) for the files.

2. Currently buttons are broken in Win10 Wi-Fi flyout. But it can be fixed just by changing the extension of **dxgi.dll** to **dxgi.bak** in `C:\Windows\SystemApps\ShellExperienceHost_cw5n1h2txyewy`
It would be great if valinet completely fixes those buttons. Bcoz they are very useful and not all people wants to play with dll's.
![2023-07-30_21h55_45](https://github.com/valinet/ExplorerPatcher/assets/93650504/3dd18429-909c-4340-93e6-a194ca571288)

And, sometimes the Windows 10 Wi-Fi flyout completely behave like broken flyout. So, this should be fixed. Here is the ss
![2023-07-31_08h36_21](https://github.com/valinet/ExplorerPatcher/assets/93650504/a9cb30bf-dd8e-48fe-a857-03655d03a588)
