### PR TITLE
EP having issues with Latest stable version 22621.2134 and Fixing Wi-Fi Flyout buttons

### DIFF
--- a/version.h
+++ b/version.h
@@ -1,7 +1,7 @@
 #define VER_MAJOR 22621
-#define VER_MINOR 1992
+#define VER_MINOR 2134
 #define VER_BUILD_HI    56
-#define VER_BUILD_LO 1
+#define VER_BUILD_LO 3
 #define VER_FLAGS   VS_FF_PRERELEASE
 
 
@@ -12,5 +12,5 @@
 #define VER_STR(arg) #arg
 
 // The String form of the version numbers
-#define VER_FILE_STRING VALUE "FileVersion", "22621.1992.55.2"
-#define VER_PRODUCT_STRING VALUE "ProductVersion", "22621.1992.55.2"
+#define VER_FILE_STRING VALUE "FileVersion", "22621.2134.56.3"
+#define VER_PRODUCT_STRING VALUE "ProductVersion", "22621.2134.56.3"

--- a/version.h
+++ b/version.h
@@ -12,5 +12,5 @@
 #define VER_STR(arg) #arg
 
 // The String form of the version numbers
-#define VER_FILE_STRING VALUE "FileVersion", "22621.1992.56.1"
-#define VER_PRODUCT_STRING VALUE "ProductVersion", "22621.1992.56.1"
+#define VER_FILE_STRING VALUE "FileVersion", "22621.1992.55.2"
+#define VER_PRODUCT_STRING VALUE "ProductVersion", "22621.1992.55.2"


### PR DESCRIPTION
Hello @valinet, firstly **SORRY🙏🙏** for tagging you. But EP is currently not working properly with the latest stable builds i.e. 22621.2134. There are so many bugs occuring with EP in 2134. List of bugs are :

1. **Action Center Overlapping** : With latest build, notification or action center is overlapping over taskbar in Win10 Taskbar style
![2023-08-12_15h19_15](https://github.com/valinet/ExplorerPatcher/assets/93650504/f4c7def9-15d6-4430-962e-be4a0ed7c482)

2. **Classic R-Click not accessible** : the classic R-click menu, which you have implemented for Win11 Taskbar, is not working anymore. If we try to access it, explorer crashes. _No Screenshot as explorer crashes._

3. **Start Folders not working** : Other buttons near Power buttons are not working anymore. We are not able to customize them.
![2023-08-12_09h12_24](https://github.com/valinet/ExplorerPatcher/assets/93650504/58357ee1-f531-4aac-ba71-239e4ed6a0de)

If it is possible, then please fix these bugs by bumping ExplorerPatcher.
---------------------------------------------------------------------------------------------------------------------------------
**(optional)** Fix for Broken Win10 Wi-Fi buttons : (steps)
1. Navigate to `C:\Windows\SystemApps\ShellExperienceHost_cw5n1h2txyewy`
2. Find and Rename the file named **dxgi.dll** to **dxgi.bak**
3. Restart the explorer.

It will Fix the Windows 10 Wi-Fi Flyout buttons completely.