### PR TITLE
Taskbar10: Try to make fixes for 22621.2134+

### DIFF
--- a/ExplorerPatcher/dllmain.c
+++ b/ExplorerPatcher/dllmain.c
@@ -11115,7 +11115,10 @@ DWORD Inject(BOOL bIsExplorer)
     if (IsWindows11())
     {
         HANDLE hInputSwitch = LoadLibraryW(L"InputSwitch.dll");
-        printf("[IME] Context menu patch status: %d\n", PatchContextMenuOfNewMicrosoftIME(NULL));
+        if (bOldTaskbar)
+        {
+            printf("[IME] Context menu patch status: %d\n", PatchContextMenuOfNewMicrosoftIME(NULL));
+        }
         if (hInputSwitch)
         {
             VnPatchIAT(hInputSwitch, "user32.dll", "TrackPopupMenuEx", inputswitch_TrackPopupMenuExHook);

--- a/ExplorerPatcher/dllmain.c
+++ b/ExplorerPatcher/dllmain.c
@@ -10817,6 +10817,167 @@ DWORD Inject(BOOL bIsExplorer)
 
 
     HANDLE hTwinuiPcshell = LoadLibraryW(L"twinui.pcshell.dll");
+    MODULEINFO miTwinuiPcshell;
+    GetModuleInformation(GetCurrentProcess(), hTwinuiPcshell, &miTwinuiPcshell, sizeof(MODULEINFO));
+
+    if (IsWindows11Version22H2OrHigher())
+    {
+        // All patterns here have been tested to work on:
+        // - 22621.1, 22621.1992, 22621.2134, 22621.2283, 22621.2359 (RP)
+        // - 23545.1000
+
+        // ZeroMemory(symbols_PTRS.twinui_pcshell_PTRS, sizeof(symbols_PTRS.twinui_pcshell_PTRS));
+        if (!symbols_PTRS.twinui_pcshell_PTRS[0] || symbols_PTRS.twinui_pcshell_PTRS[0] == 0xFFFFFFFF)
+        {
+            // Ref: CMultitaskingViewFrame::v_WndProc()
+            // 4D 8B CF 4D 8B C4 8B D6 48 8B 49 08 E8 ? ? ? ? E9
+            //                                        ^^^^^^^
+            PBYTE match = FindPattern(
+                hTwinuiPcshell,
+                miTwinuiPcshell.lpBaseOfDll,
+                "\x4D\x8B\xCF\x4D\x8B\xC4\x8B\xD6\x48\x8B\x49\x08\xE8\x00\x00\x00\x00\xE9",
+                "xxxxxxxxxxxxx????x"
+            );
+            if (match)
+            {
+                match += 12;
+                symbols_PTRS.twinui_pcshell_PTRS[0] = match + 5 + *(int*)(match + 1) - hTwinuiPcshell;
+                printf("symbols_PTRS.twinui_pcshell_PTRS[0] = %llX\n", symbols_PTRS.twinui_pcshell_PTRS[0]);
+            }
+        }
+        if (!symbols_PTRS.twinui_pcshell_PTRS[1] || symbols_PTRS.twinui_pcshell_PTRS[1] == 0xFFFFFFFF)
+        {
+            // 48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC 30 49 8B D8 48 8B FA 48 8B F1 49 83 20 00 41 B0 03 B2 01
+            PBYTE match = FindPattern(
+                hTwinuiPcshell,
+                miTwinuiPcshell.lpBaseOfDll,
+                "\x48\x89\x5C\x24\x00\x48\x89\x74\x24\x00\x57\x48\x83\xEC\x30\x49\x8B\xD8\x48\x8B\xFA\x48\x8B\xF1\x49\x83\x20\x00\x41\xB0\x03\xB2\x01",
+                "xxxx?xxxx?xxxxxxxxxxxxxxxxxxxxxxx"
+            );
+            if (match)
+            {
+                symbols_PTRS.twinui_pcshell_PTRS[1] = match - hTwinuiPcshell;
+                printf("symbols_PTRS.twinui_pcshell_PTRS[1] = %llX\n", symbols_PTRS.twinui_pcshell_PTRS[1]);
+            }
+        }
+        if (!symbols_PTRS.twinui_pcshell_PTRS[2] || symbols_PTRS.twinui_pcshell_PTRS[2] == 0xFFFFFFFF)
+        {
+            // Ref: SwitchItemThumbnailElement::ShowContextMenu()
+            // E8 ? ? ? ? E8 ? ? ? ? 0F B7 C8 E8 ? ? ? ? F7 D8
+            //    ^^^^^^^
+            PBYTE match = FindPattern(
+                hTwinuiPcshell,
+                miTwinuiPcshell.lpBaseOfDll,
+                "\xE8\x00\x00\x00\x00\xE8\x00\x00\x00\x00\x0F\xB7\xC8\xE8\x00\x00\x00\x00\xF7\xD8",
+                "x????x????xxxx????xx"
+            );
+            if (match)
+            {
+                symbols_PTRS.twinui_pcshell_PTRS[2] = match + 5 + *(int*)(match + 1) - hTwinuiPcshell;
+                printf("symbols_PTRS.twinui_pcshell_PTRS[2] = %llX\n", symbols_PTRS.twinui_pcshell_PTRS[2]);
+            }
+        }
+        if (!symbols_PTRS.twinui_pcshell_PTRS[3] || symbols_PTRS.twinui_pcshell_PTRS[3] == 0xFFFFFFFF)
+        {
+            // Ref: SwitchItemThumbnailElement::ShowContextMenu()
+            // E8 ? ? ? ? 85 DB 74 29
+            //    ^^^^^^^
+            PBYTE match = FindPattern(
+                hTwinuiPcshell,
+                miTwinuiPcshell.lpBaseOfDll,
+                "\xE8\x00\x00\x00\x00\x85\xDB\x74\x29",
+                "x????xxxx"
+            );
+            if (match)
+            {
+                symbols_PTRS.twinui_pcshell_PTRS[3] = match + 5 + *(int*)(match + 1) - hTwinuiPcshell;
+                printf("symbols_PTRS.twinui_pcshell_PTRS[3] = %llX\n", symbols_PTRS.twinui_pcshell_PTRS[3]);
+            }
+        }
+        if (!symbols_PTRS.twinui_pcshell_PTRS[4] || symbols_PTRS.twinui_pcshell_PTRS[4] == 0xFFFFFFFF)
+        {
+            // E8 ? ? ? ? 90 49 8D 56 38 49 8B CE
+            //    ^^^^^^^
+            PBYTE match = FindPattern(
+                hTwinuiPcshell,
+                miTwinuiPcshell.lpBaseOfDll,
+                "\xE8\x00\x00\x00\x00\x90\x49\x8D\x56\x38\x49\x8B\xCE",
+                "x????xxxxxxxx"
+            );
+            if (match)
+            {
+                symbols_PTRS.twinui_pcshell_PTRS[4] = match + 5 + *(int*)(match + 1) - hTwinuiPcshell;
+                printf("symbols_PTRS.twinui_pcshell_PTRS[4] = %llX\n", symbols_PTRS.twinui_pcshell_PTRS[4]);
+            }
+        }
+        if (!symbols_PTRS.twinui_pcshell_PTRS[5] || symbols_PTRS.twinui_pcshell_PTRS[5] == 0xFFFFFFFF)
+        {
+            // E8 ? ? ? ? 90 48 8D 56 38 48 8B CE
+            //    ^^^^^^^
+            PBYTE match = FindPattern(
+                hTwinuiPcshell,
+                miTwinuiPcshell.lpBaseOfDll,
+                "\xE8\x00\x00\x00\x00\x90\x48\x8D\x56\x38\x48\x8B\xCE",
+                "x????xxxxxxxx"
+            );
+            if (match)
+            {
+                symbols_PTRS.twinui_pcshell_PTRS[5] = match + 5 + *(int*)(match + 1) - hTwinuiPcshell;
+                printf("symbols_PTRS.twinui_pcshell_PTRS[5] = %llX\n", symbols_PTRS.twinui_pcshell_PTRS[5]);
+            }
+        }
+        if (!symbols_PTRS.twinui_pcshell_PTRS[6] || symbols_PTRS.twinui_pcshell_PTRS[6] == 0xFFFFFFFF)
+        {
+            // 48 83 EC 28 41 B0 03 B2 01
+            PBYTE match = FindPattern(
+                hTwinuiPcshell,
+                miTwinuiPcshell.lpBaseOfDll,
+                "\x48\x83\xEC\x28\x41\xB0\x03\xB2\x01",
+                "xxxxxxxxx"
+            );
+            if (match)
+            {
+                symbols_PTRS.twinui_pcshell_PTRS[6] = match - hTwinuiPcshell;
+                printf("symbols_PTRS.twinui_pcshell_PTRS[6] = %llX\n", symbols_PTRS.twinui_pcshell_PTRS[6]);
+            }
+        }
+        if (!symbols_PTRS.twinui_pcshell_PTRS[7] || symbols_PTRS.twinui_pcshell_PTRS[7] == 0xFFFFFFFF)
+        {
+            // Ref: CMultitaskingViewManager::_CreateMTVHost()
+            // 4C 89 74 24 ? ? 8B ? ? 8B ? 8B D7 48 8B CE E8 ? ? ? ? 8B
+            //                                               ^^^^^^^
+            PBYTE match = FindPattern(
+                hTwinuiPcshell,
+                miTwinuiPcshell.lpBaseOfDll,
+                "\x4C\x89\x74\x24\x00\x00\x8B\x00\x00\x8B\x00\x8B\xD7\x48\x8B\xCE\xE8\x00\x00\x00\x00\x8B",
+                "xxxx??x??x?xxxxxx????x"
+            );
+            if (match)
+            {
+                match += 16;
+                symbols_PTRS.twinui_pcshell_PTRS[7] = match + 5 + *(int*)(match + 1) - hTwinuiPcshell;
+                printf("symbols_PTRS.twinui_pcshell_PTRS[7] = %llX\n", symbols_PTRS.twinui_pcshell_PTRS[7]);
+            }
+        }
+        if (!symbols_PTRS.twinui_pcshell_PTRS[8] || symbols_PTRS.twinui_pcshell_PTRS[8] == 0xFFFFFFFF)
+        {
+            // Ref: CMultitaskingViewManager::_CreateMTVHost
+            // 4C 89 74 24 ? ? 8B ? ? 8B ? 8B D7 48 8B CE E8 ? ? ? ? 90
+            //                                               ^^^^^^^
+            PBYTE match = FindPattern(
+                hTwinuiPcshell,
+                miTwinuiPcshell.lpBaseOfDll,
+                "\x4C\x89\x74\x24\x00\x00\x8B\x00\x00\x8B\x00\x8B\xD7\x48\x8B\xCE\xE8\x00\x00\x00\x00\x90",
+                "xxxx??x??x?xxxxxx????x"
+            );
+            if (match)
+            {
+                match += 16;
+                symbols_PTRS.twinui_pcshell_PTRS[8] = match + 5 + *(int*)(match + 1) - hTwinuiPcshell;
+                printf("symbols_PTRS.twinui_pcshell_PTRS[8] = %llX\n", symbols_PTRS.twinui_pcshell_PTRS[8]);
+            }
+        }
+    }
 
     if (symbols_PTRS.twinui_pcshell_PTRS[0] && symbols_PTRS.twinui_pcshell_PTRS[0] != 0xFFFFFFFF)
     {

--- a/ExplorerPatcher/dllmain.c
+++ b/ExplorerPatcher/dllmain.c
@@ -10096,8 +10096,8 @@ BOOL Moment2PatchTaskView(LPMODULEINFO mi)
     22621.2283: 24A1D2
 
     Step 2:
-    In place of the 1st call's call op (E8), we overwrite it with setting the value of the reference passed into the 2nd
-    argument (rdx) to 0. This is to skip the cleanup that happens right after the 2nd call.
+    In place of the 1st call's call op (E8), overwrite it with a code to set the value of the com_ptr passed into the
+    2nd argument (rdx) to 0. This is to skip the cleanup that happens right after the 2nd call.
     ```48 C7 02 00 00 00 00 mov qword ptr [rdx], 0```
     Start from -13 of the byte after 2nd call's end.
     22621.1992: 74646
@@ -10120,10 +10120,10 @@ BOOL Moment2PatchTaskView(LPMODULEINFO mi)
 
     Notes:
     - In 22621.1992 and 22621.2134, `~AsyncOperationCompletedHandler()` is inlined, while it is not in 22621.2283. We
-      can see `unconditional_release_ref()` calls right in `RuntimeClassInitialize()` in 1992 and 2134.
-    - In 22621.2134, there is `33 FF xor edi, edi` before the jz for inlined cleanup. The value of edi is used in two
-      more cleanup calls after our area of interest, therefore we can't just NOP all those calls. And I think detecting
-      such things is too much work.
+      can see `unconditional_release_ref()` calls right in `RuntimeClassInitialize()` of 1992 and 2134.
+    - In 22621.2134, there is `33 FF xor edi, edi` before the jz for the inlined cleanup. The value of edi is used in
+      two more cleanup calls after our area of interest (those covered by twoCallsLength), therefore we can't just NOP
+      everything. And I think detecting such things is too much work.
     ***/
 
     int twoCallsLength = 1 + 18 + 4; // 4C/4D + pattern length + 4 bytes for the 2nd call's call address

--- a/ExplorerPatcher/dllmain.c
+++ b/ExplorerPatcher/dllmain.c
@@ -9872,7 +9872,7 @@ BOOL Moment2PatchActionCenter(LPMODULEINFO mi)
     Step 4:
     Change jz to jmp after the real fix, short circuiting `if (b) unconditional_release_ref(...)`.
     +11 from the movups in step 2.
-    22621.2283:
+    22621.2283: 14156
     74 -> EB
     ***/
 

--- a/ExplorerPatcher/osutility.h
+++ b/ExplorerPatcher/osutility.h
@@ -77,4 +77,12 @@ inline BOOL IsWindows11Version22H2Build1413OrHigher()
     if (global_ubr >= 1413) return TRUE;
     return FALSE;
 }
+
+inline BOOL IsWindows11Version22H2Build2134OrHigher()
+{
+    if (IsWindows11BuildHigherThan25158()) return TRUE;
+    if (!global_rovi.dwMajorVersion) global_ubr = VnGetOSVersionAndUBR(&global_rovi);
+    if (global_ubr >= 2134) return TRUE;
+    return FALSE;
+}
 #endif

--- a/ExplorerPatcher/osutility.h
+++ b/ExplorerPatcher/osutility.h
@@ -63,6 +63,13 @@ inline BOOL IsWindows11Version22H2OrHigher()
     return FALSE;
 }
 
+inline BOOL IsWindows11BuildHigherThan22631()
+{
+    if (!global_rovi.dwMajorVersion) global_ubr = VnGetOSVersionAndUBR(&global_rovi);
+    if (global_rovi.dwBuildNumber > 22631) return TRUE;
+    return FALSE;
+}
+
 inline BOOL IsWindows11BuildHigherThan25158()
 {
     if (!global_rovi.dwMajorVersion) global_ubr = VnGetOSVersionAndUBR(&global_rovi);
@@ -72,7 +79,7 @@ inline BOOL IsWindows11BuildHigherThan25158()
 
 inline BOOL IsWindows11Version22H2Build1413OrHigher()
 {
-    if (IsWindows11BuildHigherThan25158()) return TRUE;
+    if (IsWindows11BuildHigherThan22631()) return TRUE;
     if (!global_rovi.dwMajorVersion) global_ubr = VnGetOSVersionAndUBR(&global_rovi);
     if (global_ubr >= 1413) return TRUE;
     return FALSE;
@@ -80,7 +87,7 @@ inline BOOL IsWindows11Version22H2Build1413OrHigher()
 
 inline BOOL IsWindows11Version22H2Build2134OrHigher()
 {
-    if (IsWindows11BuildHigherThan25158()) return TRUE;
+    if (IsWindows11BuildHigherThan22631()) return TRUE;
     if (!global_rovi.dwMajorVersion) global_ubr = VnGetOSVersionAndUBR(&global_rovi);
     if (global_ubr >= 2134) return TRUE;
     return FALSE;

--- a/ExplorerPatcher/symbols.c
+++ b/ExplorerPatcher/symbols.c
@@ -1274,6 +1274,13 @@ BOOL LoadSymbols(symbols_addr* symbols_PTRS, HMODULE hModule)
     if (!bNeedToDownload && (!bIsTwinuiPcshellHardcoded || !bIsStartHardcoded))
     {
         bNeedToDownload = wcscmp(szReportedVersion, szStoredVersion);
+        if (bNeedToDownload)
+        {
+            ZeroMemory(
+                symbols_PTRS,
+                sizeof(symbols_addr)
+            );
+        }
     }
     return bNeedToDownload;
 }

--- a/ExplorerPatcher/utility.h
+++ b/ExplorerPatcher/utility.h
@@ -625,4 +625,30 @@ typedef struct _MonitorOverrideData
 } MonitorOverrideData;
 
 BOOL ExtractMonitorByIndex(HMONITOR hMonitor, HDC hDC, LPRECT lpRect, MonitorOverrideData* mod);
+
+inline BOOL MaskCompare(PVOID pBuffer, LPCSTR lpPattern, LPCSTR lpMask)
+{
+    for (PBYTE value = pBuffer; *lpMask; ++lpPattern, ++lpMask, ++value)
+    {
+        if (*lpMask == 'x' && *(LPCBYTE)lpPattern != *value)
+            return FALSE;
+    }
+
+    return TRUE;
+}
+
+inline PVOID FindPattern(PVOID pBase, SIZE_T dwSize, LPCSTR lpPattern, LPCSTR lpMask)
+{
+    dwSize -= strlen(lpMask);
+
+    for (SIZE_T index = 0; index < dwSize; ++index)
+    {
+        PBYTE pAddress = (PBYTE)pBase + index;
+
+        if (MaskCompare(pAddress, lpPattern, lpMask))
+            return pAddress;
+    }
+
+    return NULL;
+}
 #endif

--- a/ExplorerPatcher/utility.h
+++ b/ExplorerPatcher/utility.h
@@ -583,11 +583,12 @@ inline BOOL WINAPI PatchContextMenuOfNewMicrosoftIME(BOOL* bFound)
             {
                 *ptr = patch_to;
                 VirtualProtect(ptr, sizeof(DWORD), prot, &prot);
+                return TRUE;
             }
             break;
         }
     }
-    return TRUE;
+    return FALSE;
 }
 
 extern UINT PleaseWaitTimeout;

--- a/ExplorerPatcher/utility.h
+++ b/ExplorerPatcher/utility.h
@@ -536,7 +536,19 @@ inline BOOL WINAPI PatchContextMenuOfNewMicrosoftIME(BOOL* bFound)
 {
     // huge thanks to @Simplestas: https://github.com/valinet/ExplorerPatcher/issues/598
     if (bFound) *bFound = FALSE;
-    const DWORD patch_from = 0x50653844, patch_to = 0x54653844; // cmp byte ptr [rbp+50h], r12b
+    DWORD patch_from, patch_to;
+    if (IsWindows11Version22H2OrHigher())
+    {
+        // cmp byte ptr [rbp+40h+arg_0], r13b
+        patch_from = 0x506D3844;
+        patch_to = 0x546D3844;
+    }
+    else
+    {
+        // cmp byte ptr [rbp+50h], r12b
+        patch_from = 0x50653844;
+        patch_to = 0x54653844;
+    }
     HMODULE hInputSwitch = NULL;
     if (!GetModuleHandleExW(0, L"InputSwitch.dll", &hInputSwitch))
     {


### PR DESCRIPTION
When using the Windows 10 taskbar on Windows 11 version 22621.2134+, I've made EP to:
- Fix Action Center, Control Center, and Toast Center (notification stack) placements.
- Fix Task View refusing to appear. Also fixes Alt+Tab not working.
- Fix volume and brightness popups refusing to show.
- Fix Win+A (Action Center), Win+N (Control Center), and Win+B (Focus on tray overflow button) shortcuts not working.

As a bonus:
- On 22H2 afterwards, fixed the context menu of the new IME button.
- Prevented outdated (read: bogus) offsets from symbols saved in registry from being returned. This should help prevent a TON of appearing GitHub issues related to Explorer not loading at all after updating.
- To make this work in at least Release Preview builds, added patterns of `twinui.pcshell.dll` whose matches are used when symbols are not available or not yet downloaded.

Remaining issues:
- On 22621.2134+, with "Do not change the taskbar context menu" off, right clicking the empty spot on the Windows 11 taskbar crashes Explorer.
- Windows Ink Workspace button crashes Explorer after clicking it when the taskbar is placed at the bottom.
- On 22621.2283, https://github.com/valinet/ExplorerPatcher/issues/2108.
- Windows 10 taskbar doesn't work on 22631.2338 and 23545.1000.

The fixes have been tested to work perfectly on:
- 22621.1992
- 22621.2134
- 22621.2283
- 22621.2338 (Beta)
  - Worked perfectly without tweaks for this version after my commit that made this work on 23545.1000.
- 22621.2359 (Release Preview)
- 22631.2338 (Beta)
  - Worked perfectly without tweaks for this version after my commit that made this work on 23545.1000.
  - Although the Win10 taskbar doesn't work, the fixes were able to be applied correctly.
- 23545.1000 (Dev)
  - Although the Win10 taskbar doesn't work, the fixes were able to be applied correctly.

Important note: My methods uses patterns with masks, therefore future updates might break my methods. I've added some safeguards before applying the patches when possible, to try to prevent unwanted effects.

Further explanations are in the code I have added. Feedback is welcome :)
<img width="474" alt="image" src="https://github.com/valinet/ExplorerPatcher/assets/20662640/30cb496e-d498-4472-9c49-36aa1da2d1c1">
![image](https://github.com/valinet/ExplorerPatcher/assets/20662640/299edb40-4185-42a1-8829-403bf3b69238)
![image](https://github.com/valinet/ExplorerPatcher/assets/20662640/d389bd14-4903-410a-94dd-f47157f9697c)
![image](https://github.com/valinet/ExplorerPatcher/assets/20662640/dc06148d-c9ed-466b-9eb6-4017535c0acd)
