### PR TITLE
Freeze Windows version to Server 2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - name: Print inputs


### PR DESCRIPTION
Freezes the Windows version to Server 2022 in case the upcoming Server 2025 version is not ready yet for reproduction.