### PR TITLE
Update windows-2022 -> windows-2025, Do not persist credentials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2025
 
     steps:
       - name: Print inputs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
         if: github.event.inputs.ref == ''
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Checkout specific build and submodules
         uses: actions/checkout@v4
@@ -57,6 +58,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref }}
           submodules: recursive
+          persist-credentials: false
 
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v2


### PR DESCRIPTION
Updates the CI's OS image from Windows Server 2022 -> Windows Server 2025 basically, also credentials will not be persisted through checkouts which is to prevent exposing workflow to greater risks than imagined.