### PR TITLE
Improve the Issues tab by adding forms and auto-comment/close malware related issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,28 @@
+name: Bug report
+description: Report an issue
+labels:
+  - bug
+body:
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. Please try to isolate the issue to ExplorerPatcher by disabling other
+        customization software.
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Windows OS Build number
+      description: Find your Windows build number in the About tab of
+        ExplorerPatcher's properties window, or by running `winver`
+      placeholder: "22621.2283"
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: ExplorerPatcher version
+      description: Find your ExplorerPatcher version in the About tab of ExplorerPatcher's
+        properties window, or by going to Installed Apps in Windows Settings
+      placeholder: 22621.2283.57.2
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,7 +39,7 @@ body:
     validations:
       required: true
       
-        - type: textarea
+  - type: textarea
     attributes:
       label: Describe the bug
       description: A clear and concise description of what the bug is. Please try to isolate the issue to ExplorerPatcher by disabling other customization software.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         > [!WARNING]
-        > Issues regarding virus detections will be closed automatically. Discuss it in [valinet#3670](https://github.com/valinet/ExplorerPatcher/issues/3670) or [valinet#3228](https://github.com/valinet/ExplorerPatcher/issues/3228)
+        > Issues regarding virus detections will be closed automatically. Discuss it in [Issue #3670](https://github.com/valinet/ExplorerPatcher/issues/3670) or [Issue #3228](https://github.com/valinet/ExplorerPatcher/issues/3228)
 
   - type: checkboxes
     attributes:
@@ -23,7 +23,7 @@ body:
       label: Repro ExplorerPatcher versions
       description: Provide the relevant versions of ExplorerPatcher for reproduction of the issue.
       placeholder: |
-        Example:
+        **Example:**
         ExplorerPatcher 67.1
     validations:
       required: true
@@ -33,7 +33,7 @@ body:
       label: Repro Windows Versions
       description: Provide the relevant versions for reproduction of the issue. For example, Windows version, and architecture (e.g. x64 or ARM64).
       placeholder: |
-        Example:
+        **Example:**
         Windows 11 24H2 26100.1150 ARM64
         Windows 11 24H2 26100.2314 ARM64
     validations:
@@ -42,9 +42,9 @@ body:
   - type: textarea
     attributes:
       label: 3rd party tweak software installed
-      description: A list of 3rd Party software that modifies the taskbar in someway.
+      description: A list of 3rd Party software that may modify the shell in someway.
       placeholder: |
-        Example:
+        **Example:**
         TranslucentTB
         Windhawk (with disable grouping and vertical taskbar mods)
         OpenShell
@@ -58,7 +58,7 @@ body:
       label: Describe the bug
       description: A clear and concise description of what the bug is. Please try to isolate the issue to ExplorerPatcher by disabling other customization software.
       placeholder: |
-        Example:
+        **Example:**
         1. Install EP 67.1.
         2. Enable Windows 10 (ExplorerPatcher) taskbar and restart Explorer.
         3. Make sure Ethernet (if available) is disconnected, and then disconnect Wi-Fi.
@@ -75,7 +75,7 @@ body:
       label: Expected outcome
       description: Describe what you expected to happen when performing the steps above.
       placeholder: |
-        Example:
+        **Example:**
         The icon of the Network tray icon changes from Wi-Fi signal bars to globe (no Internet) icon like it was on 11 23H2, 11 22H2, and previous versions.
     validations:
       required: true
@@ -85,7 +85,7 @@ body:
       label: Actual outcome
       description: Describe what actually happens after performing the steps above.
       placeholder: |
-        Example:
+        **Example:**
         The icon is stuck in the Wi-Fi icon state, giving false impressions that the device is still connected to Wi-Fi. The icon will stay this way until Wi-Fi/Airplane Mode is toggled, or until the device is reconnected to a Wi-Fi router.
     validations:
       required: true
@@ -95,7 +95,7 @@ body:
       label: Additional info
       description: Provide any additional information that may help in diagnosing the issue, such as logs, error messages, or links to related issues.
       placeholder: |
-        Example:
+        **Example:**
         Windows 11 build 25236 removed pnidui.dll, leaving the restoration-from-22621 method being the only option to have this icon. However, there may be interface mismatches or API updates that caused the 22621 (22H2) pnidui.dll to behave this way on 24H2. Patches to pnidui.dll may be needed in order to fix this.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report an issue
+description: Report the issue you have with ExplorerPatcher here
 labels:
   - bug
 body:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,7 @@ body:
       description: Please ensure you meet the following criteria before reporting issues
       options:
         - label: I have confirmed that this issue does not happen when ExplorerPatcher is not installed
-        - label: I do not have register as shell extension enabled
+        - label: I do not "have register as shell extension" enabled
         - label: I have tried my best to check existing issues
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -101,6 +101,15 @@ body:
       required: false
 
   - type: textarea
+    id: crashdumps
+    attributes:
+      label: Crash Dumps
+      description: In case of crashes, if possible, please upload the latest crash dumps relating to explorer.exe. Crash dumps can be found in %LOCALAPPDATA%\CrashDumps.
+      placeholder: Drop or paste crash dumps to upload.
+    validations:
+      required: false
+
+  - type: textarea
     id: screenshots
     attributes:
       label: Media

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,7 @@ body:
       description: Please ensure you meet the following criteria before reporting issues
       options:
         - label: I have confirmed that this issue does not happen when ExplorerPatcher is not installed
-        - label: I do not "have register as shell extension" enabled
+        - label: I do not have "register as shell extension" enabled
         - label: I have tried my best to check existing issues
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
       label: Repro ExplorerPatcher versions
       description: Provide the relevant versions of ExplorerPatcher for reproduction of the issue.
       placeholder: |
-        **Example:**
+        Example:
         ExplorerPatcher 67.1
     validations:
       required: true
@@ -33,7 +33,7 @@ body:
       label: Repro Windows Versions
       description: Provide the relevant versions for reproduction of the issue. For example, Windows version, and architecture (e.g. x64 or ARM64).
       placeholder: |
-        **Example:**
+        Example:
         Windows 11 24H2 26100.1150 ARM64
         Windows 11 24H2 26100.2314 ARM64
     validations:
@@ -44,7 +44,7 @@ body:
       label: 3rd party tweak software installed
       description: A list of 3rd Party software that may modify the shell in someway.
       placeholder: |
-        **Example:**
+        Example:
         TranslucentTB
         Windhawk (with disable grouping and vertical taskbar mods)
         OpenShell
@@ -58,7 +58,7 @@ body:
       label: Describe the bug
       description: A clear and concise description of what the bug is. Please try to isolate the issue to ExplorerPatcher by disabling other customization software.
       placeholder: |
-        **Example:**
+        Example:
         1. Install EP 67.1.
         2. Enable Windows 10 (ExplorerPatcher) taskbar and restart Explorer.
         3. Make sure Ethernet (if available) is disconnected, and then disconnect Wi-Fi.
@@ -75,7 +75,7 @@ body:
       label: Expected outcome
       description: Describe what you expected to happen when performing the steps above.
       placeholder: |
-        **Example:**
+        Example:
         The icon of the Network tray icon changes from Wi-Fi signal bars to globe (no Internet) icon like it was on 11 23H2, 11 22H2, and previous versions.
     validations:
       required: true
@@ -85,7 +85,7 @@ body:
       label: Actual outcome
       description: Describe what actually happens after performing the steps above.
       placeholder: |
-        **Example:**
+        Example:
         The icon is stuck in the Wi-Fi icon state, giving false impressions that the device is still connected to Wi-Fi. The icon will stay this way until Wi-Fi/Airplane Mode is toggled, or until the device is reconnected to a Wi-Fi router.
     validations:
       required: true
@@ -95,7 +95,7 @@ body:
       label: Additional info
       description: Provide any additional information that may help in diagnosing the issue, such as logs, error messages, or links to related issues.
       placeholder: |
-        **Example:**
+        Example:
         Windows 11 build 25236 removed pnidui.dll, leaving the restoration-from-22621 method being the only option to have this icon. However, there may be interface mismatches or API updates that caused the 22621 (22H2) pnidui.dll to behave this way on 24H2. Patches to pnidui.dll may be needed in order to fix this.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -41,8 +41,8 @@ body:
       
   - type: textarea
     attributes:
-      label: Describe the bug
-      description: A clear and concise description of what the bug is. Please try to isolate the issue to ExplorerPatcher by disabling other customization software.
+      label: 3rd party tweak software installed
+      description: A list of 3rd Party software that modifies the taskbar in someway.
       placeholder: |
         Example:
         TranslucentTB

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,24 +5,73 @@ labels:
 body:
   - type: textarea
     attributes:
+      label: Repro ExplorerPatcher versions
+      description: Provide the relevant versions of ExplorerPatcher for reproduction of the issue.
+      placeholder: |
+        ExplorerPatcher 66.x
+        ExplorerPatcher 67.1
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Repro Windows Versions
+      description: Provide the relevant versions for reproduction of the issue. For example, Windows version, and architecture (e.g., ARM64).
+      placeholder: |
+        Windows 11 24H2 26100.1150 ARM64
+        Windows 11 24H2 26100.2314 ARM64
+    validations:
+      required: true
+      
+  - type: textarea
+    attributes:
       label: Describe the bug
-      description: A clear and concise description of what the bug is. Please try to isolate the issue to ExplorerPatcher by disabling other
-        customization software.
+      description: A clear and concise description of what the bug is. Please try to isolate the issue to ExplorerPatcher by disabling other customization software.
+      placeholder: |
+        1. Install EP 67.1.
+        2. Enable Windows 10 (ExplorerPatcher) taskbar and restart Explorer.
+        3. Make sure Ethernet (if available) is disconnected, and then disconnect Wi-Fi.
+        4. Turn on Personal Hotspot (iPhone) or Mobile Hotspot (Android).
+        5. Connect to the Personal Hotspot.
+        6. Observe icon changing from No Internet to Wi-Fi signal bars.
+        7. Turn off Personal Hotspot.
+        8. Observe icon staying in Wi-Fi signal bars state instead of changing to No Internet (globe icon).
     validations:
       required: true
-  - type: input
+
+  - type: textarea
     attributes:
-      label: Windows OS Build number
-      description: Find your Windows build number in the About tab of
-        ExplorerPatcher's properties window, or by running `winver`
-      placeholder: "22621.2283"
+      label: Expected outcome
+      description: Describe what you expected to happen when performing the steps above.
+      placeholder: |
+        The icon of the Network tray icon changes from Wi-Fi signal bars to globe (no Internet) icon like it was on 11 23H2, 11 22H2, and previous versions.
     validations:
       required: true
-  - type: input
+
+  - type: textarea
     attributes:
-      label: ExplorerPatcher version
-      description: Find your ExplorerPatcher version in the About tab of ExplorerPatcher's
-        properties window, or by going to Installed Apps in Windows Settings
-      placeholder: 22621.2283.57.2
+      label: Actual outcome
+      description: Describe what actually happens after performing the steps above.
+      placeholder: |
+        The icon is stuck in the Wi-Fi icon state, giving false impressions that the device is still connected to Wi-Fi. The icon will stay this way until Wi-Fi/Airplane Mode is toggled, or until the device is reconnected to a Wi-Fi router.
     validations:
       required: true
+
+  - type: textarea
+    attributes:
+      label: Additional info
+      description: Provide any additional information that may help in diagnosing the issue, such as logs, error messages, or links to related issues.
+      placeholder: |
+        Windows 11 build 25236 removed pnidui.dll, leaving the restoration-from-22621 method being the only option to have this icon. However, there may be interface mismatches or API updates that caused the 22621 (22H2) pnidui.dll to behave this way on 24H2. Patches to pnidui.dll may be needed in order to fix this.
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Media
+      description: Add screenshots/videos to help illustrate the issue
+      placeholder: Drop or paste images or videos to upload.
+    validations:
+      required: false
+

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,12 +3,27 @@ description: Report an issue
 labels:
   - bug
 body:
+  - type: markdown
+    attributes:
+      value: |
+        > [!WARNING]
+        > Issues regarding virus detections will be closed automatically. Discuss it in [valinet#3670](https://github.com/valinet/ExplorerPatcher/issues/3670) or [valinet#3228](https://github.com/valinet/ExplorerPatcher/issues/3228)
+
+  - type: checkboxes
+    attributes:
+      label: Before reporting your issue
+      description: Please ensure you meet the following criteria before reporting issues
+      options:
+        - label: I have confirmed that this issue does not happen when ExplorerPatcher is not installed
+        - label: I do not have register as shell extension enabled
+        - label: I have tried my best to check existing issues
+
   - type: textarea
     attributes:
       label: Repro ExplorerPatcher versions
       description: Provide the relevant versions of ExplorerPatcher for reproduction of the issue.
       placeholder: |
-        ExplorerPatcher 66.x
+        Example:
         ExplorerPatcher 67.1
     validations:
       required: true
@@ -16,10 +31,25 @@ body:
   - type: textarea
     attributes:
       label: Repro Windows Versions
-      description: Provide the relevant versions for reproduction of the issue. For example, Windows version, and architecture (e.g., ARM64).
+      description: Provide the relevant versions for reproduction of the issue. For example, Windows version, and architecture (e.g. x64 or ARM64).
       placeholder: |
+        Example:
         Windows 11 24H2 26100.1150 ARM64
         Windows 11 24H2 26100.2314 ARM64
+    validations:
+      required: true
+      
+        - type: textarea
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. Please try to isolate the issue to ExplorerPatcher by disabling other customization software.
+      placeholder: |
+        Example:
+        TranslucentTB
+        Windhawk (with disable grouping and vertical taskbar mods)
+        OpenShell
+        Nilesoft Shell
+        Wallpaper Engine
     validations:
       required: true
       
@@ -28,6 +58,7 @@ body:
       label: Describe the bug
       description: A clear and concise description of what the bug is. Please try to isolate the issue to ExplorerPatcher by disabling other customization software.
       placeholder: |
+        Example:
         1. Install EP 67.1.
         2. Enable Windows 10 (ExplorerPatcher) taskbar and restart Explorer.
         3. Make sure Ethernet (if available) is disconnected, and then disconnect Wi-Fi.
@@ -44,6 +75,7 @@ body:
       label: Expected outcome
       description: Describe what you expected to happen when performing the steps above.
       placeholder: |
+        Example:
         The icon of the Network tray icon changes from Wi-Fi signal bars to globe (no Internet) icon like it was on 11 23H2, 11 22H2, and previous versions.
     validations:
       required: true
@@ -53,6 +85,7 @@ body:
       label: Actual outcome
       description: Describe what actually happens after performing the steps above.
       placeholder: |
+        Example:
         The icon is stuck in the Wi-Fi icon state, giving false impressions that the device is still connected to Wi-Fi. The icon will stay this way until Wi-Fi/Airplane Mode is toggled, or until the device is reconnected to a Wi-Fi router.
     validations:
       required: true
@@ -62,6 +95,7 @@ body:
       label: Additional info
       description: Provide any additional information that may help in diagnosing the issue, such as logs, error messages, or links to related issues.
       placeholder: |
+        Example:
         Windows 11 build 25236 removed pnidui.dll, leaving the restoration-from-22621 method being the only option to have this icon. However, there may be interface mismatches or API updates that caused the 22621 (22H2) pnidui.dll to behave this way on 24H2. Patches to pnidui.dll may be needed in order to fix this.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions
+    about: Ask questions and receive support
+    url: https://github.com/valinet/ExplorerPatcher/discussions/categories/q-a
+  - name: Feature requests
+    about: Suggestions for new features and enhancements
+    url: https://github.com/valinet/ExplorerPatcher/discussions/categories/ideas
+  - name: Wiki
+    about: Useful documentation on ExplorerPatcher
+    url: https://github.com/valinet/ExplorerPatcher/wiki
+  - name: Showcase
+    about: Show off your system or give tips and tricks 
+    url: https://github.com/valinet/ExplorerPatcher/discussions/categories/show-and-tell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Questions
-    about: Ask questions and receive support
+    about: Ask questions and receive support here
     url: https://github.com/valinet/ExplorerPatcher/discussions/categories/q-a
   - name: Feature requests
-    about: Suggestions for new features and enhancements
+    about: Suggestions for new features and enhancements here
     url: https://github.com/valinet/ExplorerPatcher/discussions/categories/ideas
+  - name: Showcase
+    about: Show off your system or give tips and tricks here
+    url: https://github.com/valinet/ExplorerPatcher/discussions/categories/show-and-tell
   - name: Wiki
     about: Useful documentation on ExplorerPatcher
     url: https://github.com/valinet/ExplorerPatcher/wiki
-  - name: Showcase
-    about: Show off your system or give tips and tricks 
-    url: https://github.com/valinet/ExplorerPatcher/discussions/categories/show-and-tell

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -71,7 +71,7 @@ jobs:
 
           Microsoft, if you are reading this, please reconsider the detections as [there are a lot of users who trust this program and that risks from future EP developers are a thing.](https://www.youtube.com/watch?v=R50myh-AAe0)
 
-          This issue was closed automatically."
+          This issue was closed automatically. You want to discuss this in https://github.com/valinet/ExplorerPatcher/issues/3670."
 
           # Escape the Markdown content for proper JSON formatting
           COMMENT_BODY_ESCAPED=$(printf "%s" "$COMMENT_BODY" | jq -Rs .)

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -1,4 +1,4 @@
-name: Check Issue for Keywords
+name: MSHUWAP Issue Handler
 
 on:
   issues:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check_keywords:
-    runs-on: ubuntu-latest  # You can use any runner; Ubuntu is the most common
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -15,7 +15,7 @@ jobs:
         id: check_keywords
         run: |
           # Define the list of keywords
-          keywords=("Virus" "Malware" "Windows Defender" "Antivirus")
+          keywords=("Virus" "Malware" "Windows Defender" "Antivirus" "bitdefender" "defender" "kaspersky" "unwanted" "unwanted" "harmful")
           
           # Get the issue title and body from the event context
           ISSUE_TITLE="${{ github.event.issue.title }}"
@@ -24,7 +24,7 @@ jobs:
           # Check if any of the keywords are present in the title or body
           for keyword in "${keywords[@]}"; do
             if [[ "$ISSUE_TITLE" == *"$keyword"* ]] || [[ "$ISSUE_BODY" == *"$keyword"* ]]; then
-              echo "Keyword '$keyword' found in the issue"
+              echo "'$keyword'"
               echo "contains_keyword=true" >> $GITHUB_ENV
               break
             fi
@@ -44,5 +44,6 @@ jobs:
           # Close the issue
           curl -X PATCH \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -d '{"state": "closed"}' \
+            -d '{"state": "closed"
+            "reason":"not planned"}' \
             "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER"

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -15,16 +15,23 @@ jobs:
         id: check_keywords
         run: |
           # Define the list of keywords
-          keywords=("Virus" "Malware" "Windows Defender" "Antivirus" "bitdefender" "defender" "kaspersky" "unwanted" "unwanted" "harmful")
+          keywords=("Virus" "Malware" "Windows Defender" "Antivirus" "bitdefender" "defender" "kaspersky" "unwanted" "harmful")
           
           # Get the issue title and body from the event context
           ISSUE_TITLE="${{ github.event.issue.title }}"
           ISSUE_BODY="${{ github.event.issue.body }}"
           
+          # Convert both title and body to lowercase for case-insensitive comparison
+          ISSUE_TITLE_LOWER=$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]')
+          ISSUE_BODY_LOWER=$(echo "$ISSUE_BODY" | tr '[:upper:]' '[:lower:]')
+          
           # Check if any of the keywords are present in the title or body
           for keyword in "${keywords[@]}"; do
-            if [[ "$ISSUE_TITLE" == *"$keyword"* ]] || [[ "$ISSUE_BODY" == *"$keyword"* ]]; then
-              echo "'$keyword'"
+            # Convert the keyword to lowercase as well
+            KEYWORD_LOWER=$(echo "$keyword" | tr '[:upper:]' '[:lower:]')
+
+            if [[ "$ISSUE_TITLE_LOWER" == *"$KEYWORD_LOWER"* ]] || [[ "$ISSUE_BODY_LOWER" == *"$KEYWORD_LOWER"* ]]; then
+              echo "'$keyword' found"
               echo "contains_keyword=true" >> $GITHUB_ENV
               break
             fi
@@ -38,10 +45,7 @@ jobs:
           # Post a comment on the issue
           curl -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -d '{"body": "Bum behavior. Closed
-            i want to know
-            if these will be separate
-            or not"}' \
+            -d '{"body": "Bum behavior. Closed"}' \
             "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments"
           
           # Close the issue

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -1,19 +1,22 @@
-name: Check if issue is a known issue
+name: MSHUWAP Issue Handler
 
 on:
   issues:
-    types: [opened]  # Triggers when an issue is opened
+    types: [opened]  # Trigger when an issue is opened
 
 jobs:
   check_keywords:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Log dynamic message with issue title
+      - name: Log Custom Message with Issue Information
         run: |
-          echo "Checking issue: ${{ github.event.issue.title }} for known keywords..."
+          # Log the custom message with issue title and number for context
+          echo "Checking Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}"
+          echo "Check if issue is a known issue"
 
       - name: Check for keywords in issue title and body
         id: check_keywords
@@ -48,5 +51,5 @@ jobs:
           # Close the issue
           curl -X PATCH \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -d '{"state": "closed", "reason": "notplanned"}' \
+            -d '{"state": "closed"}' \
             "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER"

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -43,18 +43,19 @@ jobs:
           ISSUE_NUMBER="${{ github.event.issue.number }}"
 
           # Define the body of the comment with Markdown formatting
-          COMMENT_BODY="This thing
-          - is so
-          - annoying
-          - why don't you work
-          - very smart thing
+          COMMENT_BODY="Beat me to basketball
+          
+          thanks
 
-          please work."
+          I hope ."
+
+          # Use printf to properly escape the string and handle special characters (e.g., newlines, apostrophes)
+          COMMENT_BODY_ESCAPED=$(printf "%s" "$COMMENT_BODY" | jq -Rs .)
 
           # Post a comment on the issue with formatted text
           curl -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -d "{\"body\": \"$COMMENT_BODY\"}" \
+            -d "{\"body\": $COMMENT_BODY_ESCAPED}" \
             "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments"
 
           # Close the issue

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -15,7 +15,7 @@ jobs:
         id: check_keywords
         run: |
           # Define the list of keywords
-          keywords=("Virus" "Malware" "Windows Defender" "Antivirus" "bitdefender" "defender" "kaspersky" "unwanted" "harmful")
+          keywords=("Virus" "Malware" "trojan" "Windows Defender" "Antivirus" "bitdefender" "defender" "kaspersky" "unwanted" "harmful" "HackTool:Win64/ExplorerPatcher!MTB" "HackTool:Win64/Patcher!MSR" "HackTool" "Backdoor" "detection" "Norton" "Windows Security" "Win64:MalwareX-gen" "Microsoft Defender" "infected" "Potentially unwanted app found" "potentially unwanted software" "VIRUSTOTAL")
           
           # Get the issue title and body from the event context
           ISSUE_TITLE="${{ github.event.issue.title }}"

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -12,12 +12,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Log Custom Message with Issue Information
-        run: |
-          # Log the custom message with issue title and number for context
-          echo "Checking Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}"
-          echo "Check if issue is a known issue"
-
       - name: Check for keywords in issue title and body
         id: check_keywords
         run: |
@@ -27,6 +21,9 @@ jobs:
           # Get the issue title and body from the event context
           ISSUE_TITLE="${{ github.event.issue.title }}"
           ISSUE_BODY="${{ github.event.issue.body }}"
+          
+          # Log the custom message
+          echo "Checking Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}"
           
           # Check if any of the keywords are present in the title or body
           for keyword in "${keywords[@]}"; do
@@ -45,7 +42,7 @@ jobs:
           # Post a comment on the issue
           curl -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -d '{"body": "Bum behavior. Closed"}' \
+            -d '{"body": "Checking Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}\n\nBum behavior. Closed"}' \
             "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments"
           
           # Close the issue

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -2,12 +2,11 @@ name: MSHUWAP Issue Handler
 
 on:
   issues:
-    types: [opened]  # Trigger when an issue is opened
+    types: [opened]  # Triggers when an issue is opened
 
 jobs:
   check_keywords:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -16,19 +15,16 @@ jobs:
         id: check_keywords
         run: |
           # Define the list of keywords
-          keywords=("Virus" "Malware" "Windows Defender" "Antivirus" "bitdefender" "defender" "kaspersky" "unwanted" "harmful")
+          keywords=("Virus" "Malware" "Windows Defender" "Antivirus" "bitdefender" "defender" "kaspersky" "unwanted" "unwanted" "harmful")
           
           # Get the issue title and body from the event context
           ISSUE_TITLE="${{ github.event.issue.title }}"
           ISSUE_BODY="${{ github.event.issue.body }}"
           
-          # Log the custom message
-          echo "Checking Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}"
-          
           # Check if any of the keywords are present in the title or body
           for keyword in "${keywords[@]}"; do
             if [[ "$ISSUE_TITLE" == *"$keyword"* ]] || [[ "$ISSUE_BODY" == *"$keyword"* ]]; then
-              echo "'$keyword' found"
+              echo "'$keyword'"
               echo "contains_keyword=true" >> $GITHUB_ENV
               break
             fi
@@ -42,7 +38,10 @@ jobs:
           # Post a comment on the issue
           curl -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -d '{"body": "Checking Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}\n\nBum behavior. Closed"}' \
+            -d '{"body": "Bum behavior. Closed
+            i want to know
+            if these will be separate
+            or not"}' \
             "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments"
           
           # Close the issue

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -45,27 +45,27 @@ jobs:
 
           # Define the body of the comment with Markdown formatting
           COMMENT_BODY="> [!CAUTION]
-><ins>**Microsoft and other major antivirus vendors have flagged ExplorerPatcher as "malware".**</ins> This is likely due to Microsoft's hatred against ExplorerPatcher, not because it contains a virus or such. Flags from Microsoft usually spread to other antivirus vendors.
+><ins>**Microsoft and other major antivirus vendors have flagged ExplorerPatcher as \"malware\".**</ins> This is likely due to Microsoft's hatred against ExplorerPatcher, not because it contains a virus or such. Flags from Microsoft usually spread to other antivirus vendors.
 
 Please include the following files and folders in your antivirus' exclusion list to prevent issues due to antivirus detections:
 
-```
+\`\`\`
     C:\Program Files\ExplorerPatcher
     %APPDATA%\ExplorerPatcher
     C:\Windows\dxgi.dll
     C:\Windows\SystemApps\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy
     C:\Windows\SystemApps\ShellExperienceHost_cw5n1h2txyewy
-```
+\`\`\`
 
 For Defender, you can run the following script in PowerShell as an administrator:
 
-```
-Add-MpPreference -ExclusionPath "C:\Program Files\ExplorerPatcher"
-Add-MpPreference -ExclusionPath "$env:APPDATA\ExplorerPatcher"
-Add-MpPreference -ExclusionPath "C:\Windows\dxgi.dll"
-Add-MpPreference -ExclusionPath "C:\Windows\SystemApps\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy"
-Add-MpPreference -ExclusionPath "C:\Windows\SystemApps\ShellExperienceHost_cw5n1h2txyewy"
-```
+\`\`\`
+Add-MpPreference -ExclusionPath \"C:\Program Files\ExplorerPatcher\"
+Add-MpPreference -ExclusionPath \"\$env:APPDATA\ExplorerPatcher\"
+Add-MpPreference -ExclusionPath \"C:\Windows\dxgi.dll\"
+Add-MpPreference -ExclusionPath \"C:\Windows\SystemApps\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\"
+Add-MpPreference -ExclusionPath \"C:\Windows\SystemApps\ShellExperienceHost_cw5n1h2txyewy\"
+\`\`\`
 ### **Failure to exclude ExplorerPatcher's files may result in inability to install/uninstall ExplorerPatcher and explorer.exe being unable to start.**
 
 
@@ -73,9 +73,9 @@ If you do not trust this process, please refrain from using ExplorerPatcher and 
 
 Microsoft, if you are reading this, please reconsider the detections as [there are a lot of users who trust this program and that risks from future EP developers are a thing.](https://www.youtube.com/watch?v=R50myh-AAe0)
 
-Issues related to antivirus detections are closed immediately. Discuss this in https://github.com/valinet/ExplorerPatcher/issues/3670 or https://github.com/valinet/ExplorerPatcher/issues/3228.]"
+Issues related to antivirus detections are closed immediately. Discuss this in https://github.com/valinet/ExplorerPatcher/issues/3670 or https://github.com/valinet/ExplorerPatcher/issues/3228."
 
-          # Use printf to properly escape the string and handle special characters (e.g., newlines, apostrophes)
+          # Escape the Markdown content for proper JSON formatting
           COMMENT_BODY_ESCAPED=$(printf "%s" "$COMMENT_BODY" | jq -Rs .)
 
           # Post a comment on the issue with formatted text

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -19,11 +19,9 @@ jobs:
           
           # Get the issue title and body from the event context
           ISSUE_TITLE="${{ github.event.issue.title }}"
-          ISSUE_BODY="${{ github.event.issue.body }}"
           
           # Convert both title and body to lowercase for case-insensitive comparison
           ISSUE_TITLE_LOWER=$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]')
-          ISSUE_BODY_LOWER=$(echo "$ISSUE_BODY" | tr '[:upper:]' '[:lower:]')
           
           # Check if any of the keywords are present in the title or body
           for keyword in "${keywords[@]}"; do
@@ -73,7 +71,7 @@ jobs:
 
           Microsoft, if you are reading this, please reconsider the detections as [there are a lot of users who trust this program and that risks from future EP developers are a thing.](https://www.youtube.com/watch?v=R50myh-AAe0)
 
-          Issues related to antivirus detections are closed immediately. Discuss this in https://github.com/valinet/ExplorerPatcher/issues/3670 or https://github.com/valinet/ExplorerPatcher/issues/3228."
+          This issue was closed automatically. You want to discuss this in https://github.com/valinet/ExplorerPatcher/issues/3670 or https://github.com/valinet/ExplorerPatcher/issues/3228."
 
           # Escape the Markdown content for proper JSON formatting
           COMMENT_BODY_ESCAPED=$(printf "%s" "$COMMENT_BODY" | jq -Rs .)

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -1,8 +1,8 @@
-name: MSHUWAP Issue Handler
+name: Duplicate malware/virus flags issues handler
 
 on:
   issues:
-    types: [opened]  # Triggers when an issue is opened
+    types: [opened]
 
 jobs:
   check_keywords:

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -41,13 +41,86 @@ jobs:
         if: env.contains_keyword == 'true'  # Only run if a keyword was found
         run: |
           ISSUE_NUMBER="${{ github.event.issue.number }}"
-          
-          # Post a comment on the issue
+
+          # Define the body of the comment with Markdown formatting
+          COMMENT_BODY="[Verse 1]
+They told him, "Don't you ever come around here
+Don't wanna see your face, you better disappear"
+The fire's in their eyes and their words are really clear
+So beat it, just beat it (Ooh!)
+You better run, you better do what you can (Ooh!)
+Don't wanna see no blood, don't be a macho man (Ooh!)
+You wanna be tough, better do what you can
+So beat it, but you wanna be bad
+
+[Chorus]
+Just beat it (Beat it), beat it (beat it)
+No one wants to be defeated
+Show them how funky and strong is your fight
+It doesn't matter who's wrong or right
+Just beat it (Beat it)
+Just beat it (Beat it)
+Just beat it (Beat it)
+Just beat it (Beat it, ooh)
+
+[Verse 2]
+They're out to get you, better leave while you can
+Don't wanna be a boy, you wanna be a man
+You wanna stay alive, better do what you can
+So beat it, just beat it (Ooh!)
+You have to show them that you're really not scared (Ooh!)
+You're playin' with your life, this ain't no truth or dare (Ooh!)
+They'll kick you, then they'll beat you, then they'll tell you it's fair
+So beat it, but you wanna be bad
+You might also like
+Family Matters
+Drake
+Billie Jean
+Michael Jackson
+THE HEART PART 6
+Drake
+[Chorus]
+Just beat it (Beat it), beat it (beat it)
+No one wants to be defeated
+Show them how funky and strong is your fight
+It doesn't matter who's wrong or right
+Just beat it (Beat it), beat it (beat it)
+No one wants to be defeated
+Showin' how funky and strong is your fight
+It doesn't matter who's wrong or right
+Just beat it (Beat it, beat it, beat it)
+Beat it (Beat it, beat it)
+Beat it (Beat it, beat it)
+Beat it (Beat it, beat it)
+
+[Guitar Solo]
+
+[Chorus]
+Beat it (Beat it), beat it (beat it)
+No one wants to be defeated
+Show them how funky and strong is your fight
+It doesn't matter who's wrong or right (Who's right)
+Just beat it (Beat it), beat it (beat it) (hoo, hoo!)
+No one wants to be defeated (Oh, Lord)
+Show them how funky (Hee-hee!) and strong is your fight (Hee-hee-hee!)
+It doesn't matter who's wrong or right
+Just beat it (Beat it), beat it (beat it)
+No one wants to be defeated (Oh, no)
+Show them how funky (Hoo-hoo!) and strong is your fight (Hee-hee! Hoo!)
+It doesn't matter who's wrong or right
+Just beat it (Beat it), beat it (beat it)
+No one wants to be defeated
+Show them how funky and strong is your fight
+It doesn't matter who's wrong or right (Who's right)
+Just beat it (Beat it), beat it (beat it, hoo-hoo!)
+No one wants to be defeated"
+
+          # Post a comment on the issue with formatted text
           curl -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -d '{"body": "Bum behavior. Closed"}' \
+            -d "{\"body\": \"$COMMENT_BODY\"}" \
             "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments"
-          
+
           # Close the issue
           curl -X PATCH \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -43,70 +43,13 @@ jobs:
           ISSUE_NUMBER="${{ github.event.issue.number }}"
 
           # Define the body of the comment with Markdown formatting
-          COMMENT_BODY="[Verse 1]
-They told him, "Dont you ever come around here
-Dont wanna see your face, you better disappear"
-The fires in their eyes and their words are really clear
-So beat it, just beat it (Ooh!)
-You better run, you better do what you can (Ooh!)
-Dont wanna see no blood, dont be a macho man (Ooh!)
-You wanna be tough, better do what you can
-So beat it, but you wanna be bad
+          COMMENT_BODY="This thing
+          - is so
+          - annoying
+          - why don't you work
+          - very smart thing
 
-[Chorus]
-Just beat it (Beat it), beat it (beat it)
-No one wants to be defeated
-Show them how funky and strong is your fight
-It doesnt matter whos wrong or right
-Just beat it (Beat it)
-Just beat it (Beat it)
-Just beat it (Beat it)
-Just beat it (Beat it, ooh)
-
-[Verse 2]
-Theyre out to get you, better leave while you can
-Dont wanna be a boy, you wanna be a man
-You wanna stay alive, better do what you can
-So beat it, just beat it (Ooh!)
-You have to show them that youre really not scared (Ooh!)
-Youre playin with your life, this aint no truth or dare (Ooh!)
-Theyll kick you, then theyll beat you, then theyll tell you its fair
-So beat it, but you wanna be bad
-[Chorus]
-Just beat it (Beat it), beat it (beat it)
-No one wants to be defeated
-Show them how funky and strong is your fight
-It doesnt matter whos wrong or right
-Just beat it (Beat it), beat it (beat it)
-No one wants to be defeated
-Showin how funky and strong is your fight
-It doesnt matter whos wrong or right
-Just beat it (Beat it, beat it, beat it)
-Beat it (Beat it, beat it)
-Beat it (Beat it, beat it)
-Beat it (Beat it, beat it)
-
-[Guitar Solo]
-
-[Chorus]
-Beat it (Beat it), beat it (beat it)
-No one wants to be defeated
-Show them how funky and strong is your fight
-It doesnt matter whos wrong or right (Whos right)
-Just beat it (Beat it), beat it (beat it) (hoo, hoo!)
-No one wants to be defeated (Oh, Lord)
-Show them how funky (Hee-hee!) and strong is your fight (Hee-hee-hee!)
-It doesnt matter whos wrong or right
-Just beat it (Beat it), beat it (beat it)
-No one wants to be defeated (Oh, no)
-Show them how funky (Hoo-hoo!) and strong is your fight (Hee-hee! Hoo!)
-It doesnt matter whos wrong or right
-Just beat it (Beat it), beat it (beat it)
-No one wants to be defeated
-Show them how funky and strong is your fight
-It doesnt matter whos wrong or right (Whos right)
-Just beat it (Beat it), beat it (beat it, hoo-hoo!)
-No one wants to be defeated"
+          please work."
 
           # Post a comment on the issue with formatted text
           curl -X POST \

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -1,0 +1,48 @@
+name: Check Issue for Keywords
+
+on:
+  issues:
+    types: [opened]  # Triggers when an issue is opened
+
+jobs:
+  check_keywords:
+    runs-on: ubuntu-latest  # You can use any runner; Ubuntu is the most common
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Check for keywords in issue title and body
+        id: check_keywords
+        run: |
+          # Define the list of keywords
+          keywords=("Virus" "Malware" "Windows Defender" "Antivirus")
+          
+          # Get the issue title and body from the event context
+          ISSUE_TITLE="${{ github.event.issue.title }}"
+          ISSUE_BODY="${{ github.event.issue.body }}"
+          
+          # Check if any of the keywords are present in the title or body
+          for keyword in "${keywords[@]}"; do
+            if [[ "$ISSUE_TITLE" == *"$keyword"* ]] || [[ "$ISSUE_BODY" == *"$keyword"* ]]; then
+              echo "Keyword '$keyword' found in the issue"
+              echo "contains_keyword=true" >> $GITHUB_ENV
+              break
+            fi
+          done
+
+      - name: Comment and close issue if keyword found
+        if: env.contains_keyword == 'true'  # Only run if a keyword was found
+        run: |
+          ISSUE_NUMBER="${{ github.event.issue.number }}"
+          
+          # Post a comment on the issue
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -d '{"body": "Bum behavior. Closed"}' \
+            "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments"
+          
+          # Close the issue
+          curl -X PATCH \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -d '{"state": "closed"}' \
+            "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER"

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -44,12 +44,12 @@ jobs:
 
           # Define the body of the comment with Markdown formatting
           COMMENT_BODY="[Verse 1]
-They told him, "Don\'t you ever come around here
-Don\'t wanna see your face, you better disappear"
-The fire\'s in their eyes and their words are really clear
+They told him, "Dont you ever come around here
+Dont wanna see your face, you better disappear"
+The fires in their eyes and their words are really clear
 So beat it, just beat it (Ooh!)
 You better run, you better do what you can (Ooh!)
-Don\'t wanna see no blood, don\'t be a macho man (Ooh!)
+Dont wanna see no blood, dont be a macho man (Ooh!)
 You wanna be tough, better do what you can
 So beat it, but you wanna be bad
 
@@ -57,30 +57,30 @@ So beat it, but you wanna be bad
 Just beat it (Beat it), beat it (beat it)
 No one wants to be defeated
 Show them how funky and strong is your fight
-It doesn\'t matter who\'s wrong or right
+It doesnt matter whos wrong or right
 Just beat it (Beat it)
 Just beat it (Beat it)
 Just beat it (Beat it)
 Just beat it (Beat it, ooh)
 
 [Verse 2]
-They\'re out to get you, better leave while you can
-Don\'t wanna be a boy, you wanna be a man
+Theyre out to get you, better leave while you can
+Dont wanna be a boy, you wanna be a man
 You wanna stay alive, better do what you can
 So beat it, just beat it (Ooh!)
-You have to show them that you\'re really not scared (Ooh!)
-You\'re playin\' with your life, this ain\'t no truth or dare (Ooh!)
-They\'ll kick you, then they\'ll beat you, then they\'ll tell you it\'s fair
+You have to show them that youre really not scared (Ooh!)
+Youre playin with your life, this aint no truth or dare (Ooh!)
+Theyll kick you, then theyll beat you, then theyll tell you its fair
 So beat it, but you wanna be bad
 [Chorus]
 Just beat it (Beat it), beat it (beat it)
 No one wants to be defeated
 Show them how funky and strong is your fight
-It doesn\'t matter who\'s wrong or right
+It doesnt matter whos wrong or right
 Just beat it (Beat it), beat it (beat it)
 No one wants to be defeated
-Showin\' how funky and strong is your fight
-It doesn\'t matter who\'s wrong or right
+Showin how funky and strong is your fight
+It doesnt matter whos wrong or right
 Just beat it (Beat it, beat it, beat it)
 Beat it (Beat it, beat it)
 Beat it (Beat it, beat it)
@@ -92,19 +92,19 @@ Beat it (Beat it, beat it)
 Beat it (Beat it), beat it (beat it)
 No one wants to be defeated
 Show them how funky and strong is your fight
-It doesn\'t matter who\'s wrong or right (Who\'s right)
+It doesnt matter whos wrong or right (Whos right)
 Just beat it (Beat it), beat it (beat it) (hoo, hoo!)
 No one wants to be defeated (Oh, Lord)
 Show them how funky (Hee-hee!) and strong is your fight (Hee-hee-hee!)
-It doesn\'t matter who\'s wrong or right
+It doesnt matter whos wrong or right
 Just beat it (Beat it), beat it (beat it)
 No one wants to be defeated (Oh, no)
 Show them how funky (Hoo-hoo!) and strong is your fight (Hee-hee! Hoo!)
-It doesn\'t matter who\'s wrong or right
+It doesnt matter whos wrong or right
 Just beat it (Beat it), beat it (beat it)
 No one wants to be defeated
 Show them how funky and strong is your fight
-It doesn\'t matter who\'s wrong or right (Who\'s right)
+It doesnt matter whos wrong or right (Whos right)
 Just beat it (Beat it), beat it (beat it, hoo-hoo!)
 No one wants to be defeated"
 

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -71,7 +71,7 @@ jobs:
 
           Microsoft, if you are reading this, please reconsider the detections as [there are a lot of users who trust this program and that risks from future EP developers are a thing.](https://www.youtube.com/watch?v=R50myh-AAe0)
 
-          This issue was closed automatically. You want to discuss this in https://github.com/valinet/ExplorerPatcher/issues/3670 or https://github.com/valinet/ExplorerPatcher/issues/3228."
+          This issue was closed automatically."
 
           # Escape the Markdown content for proper JSON formatting
           COMMENT_BODY_ESCAPED=$(printf "%s" "$COMMENT_BODY" | jq -Rs .)

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -37,17 +37,77 @@ jobs:
             fi
           done
 
-      - name: Comment and close issue if keyword found
+      - name: Comment, label, and close issue if keyword found
         if: env.contains_keyword == 'true'  # Only run if a keyword was found
         run: |
           ISSUE_NUMBER="${{ github.event.issue.number }}"
+          REPO="${{ github.repository }}"
 
           # Define the body of the comment with Markdown formatting
-          COMMENT_BODY="Beat me to basketball
-          
-          thanks
+          COMMENT_BODY="[Verse 1]
+They told him, "Don't you ever come around here
+Don't wanna see your face, you better disappear"
+The fire's in their eyes and their words are really clear
+So beat it, just beat it (Ooh!)
+You better run, you better do what you can (Ooh!)
+Don't wanna see no blood, don't be a macho man (Ooh!)
+You wanna be tough, better do what you can
+So beat it, but you wanna be bad
 
-          I hope ."
+[Chorus]
+Just beat it (Beat it), beat it (beat it)
+No one wants to be defeated
+Show them how funky and strong is your fight
+It doesn't matter who's wrong or right
+Just beat it (Beat it)
+Just beat it (Beat it)
+Just beat it (Beat it)
+Just beat it (Beat it, ooh)
+
+[Verse 2]
+They're out to get you, better leave while you can
+Don't wanna be a boy, you wanna be a man
+You wanna stay alive, better do what you can
+So beat it, just beat it (Ooh!)
+You have to show them that you're really not scared (Ooh!)
+You're playin' with your life, this ain't no truth or dare (Ooh!)
+They'll kick you, then they'll beat you, then they'll tell you it's fair
+So beat it, but you wanna be bad
+[Chorus]
+Just beat it (Beat it), beat it (beat it)
+No one wants to be defeated
+Show them how funky and strong is your fight
+It doesn't matter who's wrong or right
+Just beat it (Beat it), beat it (beat it)
+No one wants to be defeated
+Showin' how funky and strong is your fight
+It doesn't matter who's wrong or right
+Just beat it (Beat it, beat it, beat it)
+Beat it (Beat it, beat it)
+Beat it (Beat it, beat it)
+Beat it (Beat it, beat it)
+
+[Guitar Solo]
+
+[Chorus]
+Beat it (Beat it), beat it (beat it)
+No one wants to be defeated
+Show them how funky and strong is your fight
+It doesn't matter who's wrong or right (Who's right)
+Just beat it (Beat it), beat it (beat it) (hoo, hoo!)
+No one wants to be defeated (Oh, Lord)
+Show them how funky (Hee-hee!) and strong is your fight (Hee-hee-hee!)
+It doesn't matter who's wrong or right
+Just beat it (Beat it), beat it (beat it)
+No one wants to be defeated (Oh, no)
+Show them how funky (Hoo-hoo!) and strong is your fight (Hee-hee! Hoo!)
+It doesn't matter who's wrong or right
+Just beat it (Beat it), beat it (beat it)
+No one wants to be defeated
+Show them how funky and strong is your fight
+It doesn't matter who's wrong or right (Who's right)
+Just beat it (Beat it), beat it (beat it, hoo-hoo!)
+No one wants to be defeated"
 
           # Use printf to properly escape the string and handle special characters (e.g., newlines, apostrophes)
           COMMENT_BODY_ESCAPED=$(printf "%s" "$COMMENT_BODY" | jq -Rs .)
@@ -56,10 +116,16 @@ jobs:
           curl -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -d "{\"body\": $COMMENT_BODY_ESCAPED}" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER/comments"
+            "https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/comments"
+
+          # Add the "duplicate" label to the issue
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -d '{"labels":["duplicate"]}' \
+            "https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/labels"
 
           # Close the issue
           curl -X PATCH \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -d '{"state": "closed"}' \
-            "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER"
+            "https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER"

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -44,55 +44,36 @@ jobs:
           REPO="${{ github.repository }}"
 
           # Define the body of the comment with Markdown formatting
-          COMMENT_BODY="I wish I was a little bit taller, I wish I was a baller
-I wish I had a girl who looked good, I would call her
-I wish I had a rabbit in a hat with a bat
-And a six-four Impala
+          COMMENT_BODY="> [!CAUTION]
+><ins>**Microsoft and other major antivirus vendors have flagged ExplorerPatcher as "malware".**</ins> This is likely due to Microsoft's hatred against ExplorerPatcher, not because it contains a virus or such. Flags from Microsoft usually spread to other antivirus vendors.
 
-I wish I was a little bit taller, I wish I was a baller
-I wish I had a girl who looked good, I would call her
-I wish I had a rabbit in a hat with a bat
-And a six-four Impala
+Please include the following files and folders in your antivirus' exclusion list to prevent issues due to antivirus detections:
 
-I wish I was a little bit taller, I wish I was a baller
-I wish I had a girl who looked good, I would call her
-I wish I had a rabbit in a hat with a bat
-And a six-four Impala
+```
+    C:\Program Files\ExplorerPatcher
+    %APPDATA%\ExplorerPatcher
+    C:\Windows\dxgi.dll
+    C:\Windows\SystemApps\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy
+    C:\Windows\SystemApps\ShellExperienceHost_cw5n1h2txyewy
+```
 
-I wish I was a little bit taller, I wish I was a baller
-I wish I had a girl who looked good, I would call her
-I wish I had a rabbit in a hat with a bat
-And a six-four Impala
+For Defender, you can run the following script in PowerShell as an administrator:
 
-I wish I was a little bit taller, I wish I was a baller
-I wish I had a girl who looked good, I would call her
-I wish I had a rabbit in a hat with a bat
-And a six-four Impala
+```
+Add-MpPreference -ExclusionPath "C:\Program Files\ExplorerPatcher"
+Add-MpPreference -ExclusionPath "$env:APPDATA\ExplorerPatcher"
+Add-MpPreference -ExclusionPath "C:\Windows\dxgi.dll"
+Add-MpPreference -ExclusionPath "C:\Windows\SystemApps\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy"
+Add-MpPreference -ExclusionPath "C:\Windows\SystemApps\ShellExperienceHost_cw5n1h2txyewy"
+```
+### **Failure to exclude ExplorerPatcher's files may result in inability to install/uninstall ExplorerPatcher and explorer.exe being unable to start.**
 
-I wish I was a little bit taller, I wish I was a baller
-I wish I had a girl who looked good, I would call her
-I wish I had a rabbit in a hat with a bat
-And a six-four Impala
 
-I wish I was a little bit taller, I wish I was a baller
-I wish I had a girl who looked good, I would call her
-I wish I had a rabbit in a hat with a bat
-And a six-four Impala
+If you do not trust this process, please refrain from using ExplorerPatcher and look for alternatives instead.
 
-I wish I was a little bit taller, I wish I was a baller
-I wish I had a girl who looked good, I would call her
-I wish I had a rabbit in a hat with a bat
-And a six-four Impala
+Microsoft, if you are reading this, please reconsider the detections as [there are a lot of users who trust this program and that risks from future EP developers are a thing.](https://www.youtube.com/watch?v=R50myh-AAe0)
 
-I wish I was a little bit taller, I wish I was a baller
-I wish I had a girl who looked good, I would call her
-I wish I had a rabbit in a hat with a bat
-And a six-four Impala
-
-I wish I was a little bit taller, I wish I was a baller
-I wish I had a girl who looked good, I would call her
-I wish I had a rabbit in a hat with a bat
-And a six-four Impala"
+Issues related to antivirus detections are closed immediately. Discuss this in https://github.com/valinet/ExplorerPatcher/issues/3670 or https://github.com/valinet/ExplorerPatcher/issues/3228.]"
 
           # Use printf to properly escape the string and handle special characters (e.g., newlines, apostrophes)
           COMMENT_BODY_ESCAPED=$(printf "%s" "$COMMENT_BODY" | jq -Rs .)

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -44,70 +44,55 @@ jobs:
           REPO="${{ github.repository }}"
 
           # Define the body of the comment with Markdown formatting
-          COMMENT_BODY="[Verse 1]
-They told him, "Don't you ever come around here
-Don't wanna see your face, you better disappear"
-The fire's in their eyes and their words are really clear
-So beat it, just beat it (Ooh!)
-You better run, you better do what you can (Ooh!)
-Don't wanna see no blood, don't be a macho man (Ooh!)
-You wanna be tough, better do what you can
-So beat it, but you wanna be bad
+          COMMENT_BODY="I wish I was a little bit taller, I wish I was a baller
+I wish I had a girl who looked good, I would call her
+I wish I had a rabbit in a hat with a bat
+And a six-four Impala
 
-[Chorus]
-Just beat it (Beat it), beat it (beat it)
-No one wants to be defeated
-Show them how funky and strong is your fight
-It doesn't matter who's wrong or right
-Just beat it (Beat it)
-Just beat it (Beat it)
-Just beat it (Beat it)
-Just beat it (Beat it, ooh)
+I wish I was a little bit taller, I wish I was a baller
+I wish I had a girl who looked good, I would call her
+I wish I had a rabbit in a hat with a bat
+And a six-four Impala
 
-[Verse 2]
-They're out to get you, better leave while you can
-Don't wanna be a boy, you wanna be a man
-You wanna stay alive, better do what you can
-So beat it, just beat it (Ooh!)
-You have to show them that you're really not scared (Ooh!)
-You're playin' with your life, this ain't no truth or dare (Ooh!)
-They'll kick you, then they'll beat you, then they'll tell you it's fair
-So beat it, but you wanna be bad
-[Chorus]
-Just beat it (Beat it), beat it (beat it)
-No one wants to be defeated
-Show them how funky and strong is your fight
-It doesn't matter who's wrong or right
-Just beat it (Beat it), beat it (beat it)
-No one wants to be defeated
-Showin' how funky and strong is your fight
-It doesn't matter who's wrong or right
-Just beat it (Beat it, beat it, beat it)
-Beat it (Beat it, beat it)
-Beat it (Beat it, beat it)
-Beat it (Beat it, beat it)
+I wish I was a little bit taller, I wish I was a baller
+I wish I had a girl who looked good, I would call her
+I wish I had a rabbit in a hat with a bat
+And a six-four Impala
 
-[Guitar Solo]
+I wish I was a little bit taller, I wish I was a baller
+I wish I had a girl who looked good, I would call her
+I wish I had a rabbit in a hat with a bat
+And a six-four Impala
 
-[Chorus]
-Beat it (Beat it), beat it (beat it)
-No one wants to be defeated
-Show them how funky and strong is your fight
-It doesn't matter who's wrong or right (Who's right)
-Just beat it (Beat it), beat it (beat it) (hoo, hoo!)
-No one wants to be defeated (Oh, Lord)
-Show them how funky (Hee-hee!) and strong is your fight (Hee-hee-hee!)
-It doesn't matter who's wrong or right
-Just beat it (Beat it), beat it (beat it)
-No one wants to be defeated (Oh, no)
-Show them how funky (Hoo-hoo!) and strong is your fight (Hee-hee! Hoo!)
-It doesn't matter who's wrong or right
-Just beat it (Beat it), beat it (beat it)
-No one wants to be defeated
-Show them how funky and strong is your fight
-It doesn't matter who's wrong or right (Who's right)
-Just beat it (Beat it), beat it (beat it, hoo-hoo!)
-No one wants to be defeated"
+I wish I was a little bit taller, I wish I was a baller
+I wish I had a girl who looked good, I would call her
+I wish I had a rabbit in a hat with a bat
+And a six-four Impala
+
+I wish I was a little bit taller, I wish I was a baller
+I wish I had a girl who looked good, I would call her
+I wish I had a rabbit in a hat with a bat
+And a six-four Impala
+
+I wish I was a little bit taller, I wish I was a baller
+I wish I had a girl who looked good, I would call her
+I wish I had a rabbit in a hat with a bat
+And a six-four Impala
+
+I wish I was a little bit taller, I wish I was a baller
+I wish I had a girl who looked good, I would call her
+I wish I had a rabbit in a hat with a bat
+And a six-four Impala
+
+I wish I was a little bit taller, I wish I was a baller
+I wish I had a girl who looked good, I would call her
+I wish I had a rabbit in a hat with a bat
+And a six-four Impala
+
+I wish I was a little bit taller, I wish I was a baller
+I wish I had a girl who looked good, I would call her
+I wish I had a rabbit in a hat with a bat
+And a six-four Impala"
 
           # Use printf to properly escape the string and handle special characters (e.g., newlines, apostrophes)
           COMMENT_BODY_ESCAPED=$(printf "%s" "$COMMENT_BODY" | jq -Rs .)

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -1,4 +1,4 @@
-name: MSHUWAP Issue Handler
+name: Check if issue is a known issue
 
 on:
   issues:
@@ -7,14 +7,13 @@ on:
 jobs:
   check_keywords:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Log check message
+      - name: Log dynamic message with issue title
         run: |
-          echo "Check if issue is a known issue"
+          echo "Checking issue: ${{ github.event.issue.title }} for known keywords..."
 
       - name: Check for keywords in issue title and body
         id: check_keywords
@@ -49,5 +48,5 @@ jobs:
           # Close the issue
           curl -X PATCH \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -d '{"state": "closed", "reason": "not planned"}' \
+            -d '{"state": "closed", "reason": "notplanned"}' \
             "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER"

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -68,7 +68,6 @@ Add-MpPreference -ExclusionPath \"C:\Windows\SystemApps\ShellExperienceHost_cw5n
 \`\`\`
 ### **Failure to exclude ExplorerPatcher's files may result in inability to install/uninstall ExplorerPatcher and explorer.exe being unable to start.**
 
-
 If you do not trust this process, please refrain from using ExplorerPatcher and look for alternatives instead.
 
 Microsoft, if you are reading this, please reconsider the detections as [there are a lot of users who trust this program and that risks from future EP developers are a thing.](https://www.youtube.com/watch?v=R50myh-AAe0)

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -72,13 +72,6 @@ You have to show them that you're really not scared (Ooh!)
 You're playin' with your life, this ain't no truth or dare (Ooh!)
 They'll kick you, then they'll beat you, then they'll tell you it's fair
 So beat it, but you wanna be bad
-You might also like
-Family Matters
-Drake
-Billie Jean
-Michael Jackson
-THE HEART PART 6
-Drake
 [Chorus]
 Just beat it (Beat it), beat it (beat it)
 No one wants to be defeated

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -7,15 +7,20 @@ on:
 jobs:
   check_keywords:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Log check message
+        run: |
+          echo "Check if issue is a known issue"
 
       - name: Check for keywords in issue title and body
         id: check_keywords
         run: |
           # Define the list of keywords
-          keywords=("Virus" "Malware" "Windows Defender" "Antivirus" "bitdefender" "defender" "kaspersky" "unwanted" "unwanted" "harmful")
+          keywords=("Virus" "Malware" "Windows Defender" "Antivirus" "bitdefender" "defender" "kaspersky" "unwanted" "harmful")
           
           # Get the issue title and body from the event context
           ISSUE_TITLE="${{ github.event.issue.title }}"
@@ -24,7 +29,7 @@ jobs:
           # Check if any of the keywords are present in the title or body
           for keyword in "${keywords[@]}"; do
             if [[ "$ISSUE_TITLE" == *"$keyword"* ]] || [[ "$ISSUE_BODY" == *"$keyword"* ]]; then
-              echo "'$keyword'"
+              echo "'$keyword' found"
               echo "contains_keyword=true" >> $GITHUB_ENV
               break
             fi
@@ -44,6 +49,5 @@ jobs:
           # Close the issue
           curl -X PATCH \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -d '{"state": "closed"
-            "reason":"not planned"}' \
+            -d '{"state": "closed", "reason": "not planned"}' \
             "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUMBER"

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -44,12 +44,12 @@ jobs:
 
           # Define the body of the comment with Markdown formatting
           COMMENT_BODY="[Verse 1]
-They told him, "Don't you ever come around here
-Don't wanna see your face, you better disappear"
-The fire's in their eyes and their words are really clear
+They told him, "Don\'t you ever come around here
+Don\'t wanna see your face, you better disappear"
+The fire\'s in their eyes and their words are really clear
 So beat it, just beat it (Ooh!)
 You better run, you better do what you can (Ooh!)
-Don't wanna see no blood, don't be a macho man (Ooh!)
+Don\'t wanna see no blood, don\'t be a macho man (Ooh!)
 You wanna be tough, better do what you can
 So beat it, but you wanna be bad
 
@@ -57,30 +57,30 @@ So beat it, but you wanna be bad
 Just beat it (Beat it), beat it (beat it)
 No one wants to be defeated
 Show them how funky and strong is your fight
-It doesn't matter who's wrong or right
+It doesn\'t matter who\'s wrong or right
 Just beat it (Beat it)
 Just beat it (Beat it)
 Just beat it (Beat it)
 Just beat it (Beat it, ooh)
 
 [Verse 2]
-They're out to get you, better leave while you can
-Don't wanna be a boy, you wanna be a man
+They\'re out to get you, better leave while you can
+Don\'t wanna be a boy, you wanna be a man
 You wanna stay alive, better do what you can
 So beat it, just beat it (Ooh!)
-You have to show them that you're really not scared (Ooh!)
-You're playin' with your life, this ain't no truth or dare (Ooh!)
-They'll kick you, then they'll beat you, then they'll tell you it's fair
+You have to show them that you\'re really not scared (Ooh!)
+You\'re playin\' with your life, this ain\'t no truth or dare (Ooh!)
+They\'ll kick you, then they\'ll beat you, then they\'ll tell you it\'s fair
 So beat it, but you wanna be bad
 [Chorus]
 Just beat it (Beat it), beat it (beat it)
 No one wants to be defeated
 Show them how funky and strong is your fight
-It doesn't matter who's wrong or right
+It doesn\'t matter who\'s wrong or right
 Just beat it (Beat it), beat it (beat it)
 No one wants to be defeated
-Showin' how funky and strong is your fight
-It doesn't matter who's wrong or right
+Showin\' how funky and strong is your fight
+It doesn\'t matter who\'s wrong or right
 Just beat it (Beat it, beat it, beat it)
 Beat it (Beat it, beat it)
 Beat it (Beat it, beat it)
@@ -92,19 +92,19 @@ Beat it (Beat it, beat it)
 Beat it (Beat it), beat it (beat it)
 No one wants to be defeated
 Show them how funky and strong is your fight
-It doesn't matter who's wrong or right (Who's right)
+It doesn\'t matter who\'s wrong or right (Who\'s right)
 Just beat it (Beat it), beat it (beat it) (hoo, hoo!)
 No one wants to be defeated (Oh, Lord)
 Show them how funky (Hee-hee!) and strong is your fight (Hee-hee-hee!)
-It doesn't matter who's wrong or right
+It doesn\'t matter who\'s wrong or right
 Just beat it (Beat it), beat it (beat it)
 No one wants to be defeated (Oh, no)
 Show them how funky (Hoo-hoo!) and strong is your fight (Hee-hee! Hoo!)
-It doesn't matter who's wrong or right
+It doesn\'t matter who\'s wrong or right
 Just beat it (Beat it), beat it (beat it)
 No one wants to be defeated
 Show them how funky and strong is your fight
-It doesn't matter who's wrong or right (Who's right)
+It doesn\'t matter who\'s wrong or right (Who\'s right)
 Just beat it (Beat it), beat it (beat it, hoo-hoo!)
 No one wants to be defeated"
 

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -42,37 +42,38 @@ jobs:
         run: |
           ISSUE_NUMBER="${{ github.event.issue.number }}"
           REPO="${{ github.repository }}"
-
+          
           # Define the body of the comment with Markdown formatting
           COMMENT_BODY="> [!CAUTION]
-><ins>**Microsoft and other major antivirus vendors have flagged ExplorerPatcher as \"malware\".**</ins> This is likely due to Microsoft's hatred against ExplorerPatcher, not because it contains a virus or such. Flags from Microsoft usually spread to other antivirus vendors.
+          ><ins>**Microsoft and other major antivirus vendors have flagged ExplorerPatcher as \"malware\".**</ins> This is likely due to Microsoft's hatred against ExplorerPatcher, not because it contains a virus or such. Flags from Microsoft usually spread to other antivirus vendors.
 
-Please include the following files and folders in your antivirus' exclusion list to prevent issues due to antivirus detections:
+          Please include the following files and folders in your antivirus' exclusion list to prevent issues due to antivirus detections:
 
-\`\`\`
-    C:\Program Files\ExplorerPatcher
-    %APPDATA%\ExplorerPatcher
-    C:\Windows\dxgi.dll
-    C:\Windows\SystemApps\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy
-    C:\Windows\SystemApps\ShellExperienceHost_cw5n1h2txyewy
-\`\`\`
+          \`\`\`
+          C:\Program Files\ExplorerPatcher
+          %APPDATA%\ExplorerPatcher
+          C:\Windows\dxgi.dll
+          C:\Windows\SystemApps\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy
+          C:\Windows\SystemApps\ShellExperienceHost_cw5n1h2txyewy
+          \`\`\`
 
-For Defender, you can run the following script in PowerShell as an administrator:
+          For Defender, you can run the following script in PowerShell as an administrator:
 
-\`\`\`
-Add-MpPreference -ExclusionPath \"C:\Program Files\ExplorerPatcher\"
-Add-MpPreference -ExclusionPath \"\$env:APPDATA\ExplorerPatcher\"
-Add-MpPreference -ExclusionPath \"C:\Windows\dxgi.dll\"
-Add-MpPreference -ExclusionPath \"C:\Windows\SystemApps\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\"
-Add-MpPreference -ExclusionPath \"C:\Windows\SystemApps\ShellExperienceHost_cw5n1h2txyewy\"
-\`\`\`
-### **Failure to exclude ExplorerPatcher's files may result in inability to install/uninstall ExplorerPatcher and explorer.exe being unable to start.**
+          \`\`\`
+          Add-MpPreference -ExclusionPath \"C:\Program Files\ExplorerPatcher\"
+          Add-MpPreference -ExclusionPath \"\$env:APPDATA\ExplorerPatcher\"
+          Add-MpPreference -ExclusionPath \"C:\Windows\dxgi.dll\"
+          Add-MpPreference -ExclusionPath \"C:\Windows\SystemApps\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\"
+          Add-MpPreference -ExclusionPath \"C:\Windows\SystemApps\ShellExperienceHost_cw5n1h2txyewy\"
+          \`\`\`
+          
+          ### **Failure to exclude ExplorerPatcher's files may result in inability to install/uninstall ExplorerPatcher and explorer.exe being unable to start.**
 
-If you do not trust this process, please refrain from using ExplorerPatcher and look for alternatives instead.
+          If you do not trust this process, please refrain from using ExplorerPatcher and look for alternatives instead.
 
-Microsoft, if you are reading this, please reconsider the detections as [there are a lot of users who trust this program and that risks from future EP developers are a thing.](https://www.youtube.com/watch?v=R50myh-AAe0)
+          Microsoft, if you are reading this, please reconsider the detections as [there are a lot of users who trust this program and that risks from future EP developers are a thing.](https://www.youtube.com/watch?v=R50myh-AAe0)
 
-Issues related to antivirus detections are closed immediately. Discuss this in https://github.com/valinet/ExplorerPatcher/issues/3670 or https://github.com/valinet/ExplorerPatcher/issues/3228."
+          Issues related to antivirus detections are closed immediately. Discuss this in https://github.com/valinet/ExplorerPatcher/issues/3670 or https://github.com/valinet/ExplorerPatcher/issues/3228."
 
           # Escape the Markdown content for proper JSON formatting
           COMMENT_BODY_ESCAPED=$(printf "%s" "$COMMENT_BODY" | jq -Rs .)


### PR DESCRIPTION
This pull request overhauls the entire Issues tab by implementing templates that were taken from https://github.com/valinet/ExplorerPatcher/pull/2166 and improved upon by a new bug report form

![The new issues form](https://github.com/user-attachments/assets/2b3f6a5b-08f0-4a06-bc87-b01e504ab735)

Bug Report Form:

![Bug Report Form 1](https://github.com/user-attachments/assets/692fc088-616c-40a8-8a01-c66e084de704)
![Bug Report Form 2](https://github.com/user-attachments/assets/20867f2e-50f4-4834-9ed1-c6f9a261a0fe)

Also, this pull request adds an issue handler powered via GitHub actions that checks thru a list of keywords (mostly related to malware/virus/etc...) and will add a comment explaining the same paragraph as shown in releases, will add the "Duplicate" label to the issue and will close the issue.

Example:
![Example of an issue that was closed due to the title containing a reference to "virus"](https://github.com/user-attachments/assets/ba3b0be2-3fe9-44b3-9f7a-e4b056e6187d)
