### PR TITLE
Hide the win8 network flyout as an option on Win 11 after 25346 as van.dll was removed

### DIFF
--- a/ExplorerPatcher/osutility.h
+++ b/ExplorerPatcher/osutility.h
@@ -78,6 +78,12 @@ inline BOOL IsWindows11BuildHigherThan25158()
     return global_rovi.dwBuildNumber > 25158;
 }
 
+inline BOOL IsWindows11Build25346OrHigher()
+{
+    if (!global_rovi.dwMajorVersion) global_ubr = VnGetOSVersionAndUBR(&global_rovi);
+    return global_rovi.dwBuildNumber >= 25346;
+}
+
 inline BOOL IsWindows11Version22H2Build1413OrHigher()
 {
     if (!global_rovi.dwMajorVersion) global_ubr = VnGetOSVersionAndUBR(&global_rovi);

--- a/ep_gui/GUI.c
+++ b/ep_gui/GUI.c
@@ -2571,6 +2571,23 @@ static BOOL GUI_Build(HDC hDC, HWND hwnd, POINT pt)
                                 RemoveMenu(hMenu, 3, MF_BYCOMMAND);
                             }
                         }
+                        else if (!wcscmp(name, L"ReplaceVan"))
+                        {
+                            if (IsWindows11Build25346OrHigher())
+                            {
+                                // Hide the win8 network flyout as an option on Win 11 after 25346 as van.dll was removed
+                                MENUITEMINFOA menuInfo;
+                                ZeroMemory(&menuInfo, sizeof(MENUITEMINFOA));
+                                menuInfo.cbSize = sizeof(MENUITEMINFOA);
+                                menuInfo.fMask = MIIM_DATA;
+                                GetMenuItemInfoA(hMenu, 3, FALSE, &menuInfo);
+                                if (menuInfo.dwItemData)
+                                {
+                                    free(menuInfo.dwItemData);
+                                }
+                                RemoveMenu(hMenu, 3, MF_BYCOMMAND);
+                            }
+                        }
                         HKEY hKey = NULL;
                         wchar_t* matchHKLM = wcsstr(section, L"HKEY_LOCAL_MACHINE");
                         BOOL bIsHKLM = matchHKLM && (matchHKLM - section) < 3;

--- a/ep_gui/GUI.c
+++ b/ep_gui/GUI.c
@@ -2575,26 +2575,17 @@ static BOOL GUI_Build(HDC hDC, HWND hwnd, POINT pt)
                         {
                             if (IsWindows11Build25346OrHigher())
                             {
+                                // Hide the win8 network flyout as an option on Win 11 after 25346 as van.dll was removed
                                 MENUITEMINFOA menuInfo;
                                 ZeroMemory(&menuInfo, sizeof(MENUITEMINFOA));
                                 menuInfo.cbSize = sizeof(MENUITEMINFOA);
                                 menuInfo.fMask = MIIM_DATA;
-                                
-                                // Hide the win8 network flyout as an option on Win 11 after 25346 as van.dll was removed
                                 GetMenuItemInfoA(hMenu, 3, FALSE, &menuInfo);
                                 if (menuInfo.dwItemData)
                                 {
                                     free(menuInfo.dwItemData);
                                 }
                                 RemoveMenu(hMenu, 3, MF_BYCOMMAND);
-                                
-                                // Hide the control center option as this doesn't work either
-                                GetMenuItemInfoA(hMenu, 7, FALSE, &menuInfo);
-                                if (menuInfo.dwItemData)
-                                {
-                                    free(menuInfo.dwItemData);
-                                }
-                                RemoveMenu(hMenu, 7, MF_BYCOMMAND);
                             }
                         }
                         HKEY hKey = NULL;

--- a/ep_gui/GUI.c
+++ b/ep_gui/GUI.c
@@ -2575,17 +2575,26 @@ static BOOL GUI_Build(HDC hDC, HWND hwnd, POINT pt)
                         {
                             if (IsWindows11Build25346OrHigher())
                             {
-                                // Hide the win8 network flyout as an option on Win 11 after 25346 as van.dll was removed
                                 MENUITEMINFOA menuInfo;
                                 ZeroMemory(&menuInfo, sizeof(MENUITEMINFOA));
                                 menuInfo.cbSize = sizeof(MENUITEMINFOA);
                                 menuInfo.fMask = MIIM_DATA;
+                                
+                                // Hide the win8 network flyout as an option on Win 11 after 25346 as van.dll was removed
                                 GetMenuItemInfoA(hMenu, 3, FALSE, &menuInfo);
                                 if (menuInfo.dwItemData)
                                 {
                                     free(menuInfo.dwItemData);
                                 }
                                 RemoveMenu(hMenu, 3, MF_BYCOMMAND);
+                                
+                                // Hide the control center option as this doesn't work either
+                                GetMenuItemInfoA(hMenu, 7, FALSE, &menuInfo);
+                                if (menuInfo.dwItemData)
+                                {
+                                    free(menuInfo.dwItemData);
+                                }
+                                RemoveMenu(hMenu, 7, MF_BYCOMMAND);
                             }
                         }
                         HKEY hKey = NULL;


### PR DESCRIPTION
Hide the win8 network flyout as an option on Win 11 after 25346 as van.dll was removed.