### PR TITLE
Improve workflow system for EP further

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,12 @@ jobs:
             done
           fi
 
+      - name: Build ExplorerPatcher (IA-32)
+        if: github.event.inputs.config == ''
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+        run: |
+          msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=IA-32 ${{env.SOLUTION_FILE_PATH}}
+
       - name: Build ExplorerPatcher (amd64)
         if: github.event.inputs.config == ''
         working-directory: ${{env.GITHUB_WORKSPACE}}
@@ -254,4 +260,5 @@ jobs:
             build/Release/ep_setup_arm64.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 


### PR DESCRIPTION
1. Drops the unneeded push and pull_request rules as they don't do anything unlike workflow_dispatch's rules,
2. Sets the contents permission to write in case the workflow becomes read-only by default,
3. Pins all job versions to their commit hashes to avoid [supply chain attacks towards the workflow script](https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash),
4. Moves all environment mentions into the `env:` section to prevent causing them from getting expanded into attacker-controllable code,
~~5. Kills off 32-bit compilation in the workflow system as Windows 11 overall is amd64+arm64 only now, *(`22000.51` does exist as x86 but is in corpnet only at time of writing)*~~
6. Freezes the nuget version to 7.x,
7. Adds the `timeout-minutes` to the job(s) section so that the CI doesn't take 6 hours straight to get aborted in case something is causing the CI to suddenly stall or become unresponsive, *(this can be adjusted if 30 mins is too short or too long)*
8. Sets the `if-no-files-found` to error by default in case artifacts are absent.

*(Security issues were all spotted by zizmor)*