### PR TITLE
Fix for bug where Recommended section would re-appear

### DIFF
--- a/ExplorerPatcher/dllmain.c
+++ b/ExplorerPatcher/dllmain.c
@@ -11538,6 +11538,56 @@ DWORD StartUI_EnableRoundedCornersApply = TRUE;
 DWORD StartUI_ShowMoreTiles = FALSE;
 HKEY hKey_StartUI_TileGrid = NULL;
 
+/*
+ * Fix bug where Recommended section would re-appear.
+ *
+ *   Various interactions inside the Start Menu would trigger OnSettingChanged(),
+ *   which in turn calls UpdatePinnedListHeight(), which causes the problem.
+ *   So hook OnSettingChanged(), mark that it has been called, and, when
+ *   UpdatePinnedListHeight() is called afterwards, return from it.
+ * 
+ *   Pinned List Height can still be adjusted from Settings.
+ *
+ */
+
+static BOOL b_IsFromOnSettingChanged = 0;
+
+typedef uintptr_t (__fastcall* StartMenu_OnSettingChanged_t)(
+    void* _this,
+    uintptr_t param_2,
+    void* param_3,
+    void* param_4
+);
+
+typedef void(__fastcall* StartMenu_UpdatePinnedListHeight_t)(
+    void* _this
+    );
+
+static StartMenu_OnSettingChanged_t StartMenu_OnSettingChangedFunc = NULL;
+
+static StartMenu_UpdatePinnedListHeight_t
+StartMenu_UpdatePinnedListHeightFunc = NULL;
+
+void __fastcall StartMenu_OnSettingChangedHook(void* _this, uintptr_t param_2, void* param_3, void* param_4)
+{
+    // Mark that OnSettingChanged() has ran
+    b_IsFromOnSettingChanged = TRUE;
+    StartMenu_OnSettingChangedFunc(_this, param_2, param_3, param_4);
+}
+
+void __fastcall StartMenu_UpdatePinnedListHeightHook(void* _this)
+{
+    // If call is coming from OnSettingChanged(), return; 
+    if (b_IsFromOnSettingChanged)
+    {
+        b_IsFromOnSettingChanged = FALSE;
+        return;
+    }
+
+    // Call original function, if call is not coming from OnSettingChanged()
+    StartMenu_UpdatePinnedListHeightFunc(_this);
+}
+
 void StartMenu_LoadSettings(BOOL bRestartIfChanged)
 {
     HKEY hKey = NULL;
@@ -12686,6 +12736,7 @@ DWORD InjectStartMenu()
 
     HANDLE hStartDocked = NULL;
     HANDLE hStartUI = NULL;
+    HANDLE hStartMenu = NULL;
 
     if (!IsWindows11()) dwTaskbarAl = 0;
 
@@ -12731,6 +12782,18 @@ DWORD InjectStartMenu()
         hStartDocked = GetModuleHandleW(L"StartDocked.dll");
 
         VnPatchDelayIAT(hStartDocked, "ext-ms-win-ntuser-draw-l1-1-0.dll", "SetWindowRgn", Start_SetWindowRgn);
+
+        WCHAR wszStartMenuDll[MAX_PATH];
+        GetWindowsDirectoryW(wszStartMenuDll, MAX_PATH);
+        wcscat_s(
+            wszStartMenuDll,
+            MAX_PATH,
+            L"\\SystemApps\\MicrosoftWindows.Client.Core_cw5n1h2txyewy\\StartMenu.dll"
+        );
+        hStartMenu = LoadLibraryExW(wszStartMenuDll,
+                                    NULL,
+                                    LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS
+        );
     }
 
     Setting* settings = calloc(6, sizeof(Setting));
@@ -12785,6 +12848,8 @@ DWORD InjectStartMenu()
 
     int rv;
     DWORD dwVal0 = 0, dwVal1 = 0, dwVal2 = 0, dwVal3 = 0, dwVal4 = 0;
+    DWORD dwStartMenuOnSettingChanged = 0;
+    DWORD dwStartMenuUpdatePinnedListHeight = 0;
 
     HMODULE hModule = LoadLibraryExW(L"Shlwapi.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
     if (hModule)
@@ -12835,6 +12900,24 @@ DWORD InjectStartMenu()
                 &dwVal4,
                 &dwSize
             );
+            dwSize = sizeof(DWORD);
+            SHRegGetValueFromHKCUHKLM(
+                TEXT(REGPATH_STARTMENU) TEXT("\\") TEXT(STARTMENU_SB_NAME),
+                TEXT(STARTMENU_SB_STARTINNERFRAME_ONSETTINGCHANGED),
+                SRRF_RT_REG_DWORD,
+                NULL,
+                &dwStartMenuOnSettingChanged,
+                &dwSize
+            );
+            dwSize = sizeof(DWORD);
+            SHRegGetValueFromHKCUHKLM(
+                TEXT(REGPATH_STARTMENU) TEXT("\\") TEXT(STARTMENU_SB_NAME),
+                TEXT(STARTMENU_SB_STARTINNERFRAME_UPDATEPINNEDLISTHEIGHT),
+                SRRF_RT_REG_DWORD,
+                NULL,
+                &dwStartMenuUpdatePinnedListHeight,
+                &dwSize
+            );
         }
         FreeLibrary(hModule);
     }
@@ -12882,6 +12965,39 @@ DWORD InjectStartMenu()
             funchook,
             (void**)&StartUI_SystemListPolicyProvider_GetMaximumFrequentAppsFunc,
             StartUI_SystemListPolicyProvider_GetMaximumFrequentAppsHook
+        );
+        if (rv != 0)
+        {
+            FreeLibraryAndExitThread(hModule, rv);
+            return rv;
+        }
+    }
+
+    if (hStartMenu &&
+        dwStartMenuOnSettingChanged &&
+        dwStartMenuUpdatePinnedListHeight)
+    {
+        StartMenu_OnSettingChangedFunc = (StartMenu_OnSettingChanged_t)
+            ((uintptr_t)hStartMenu + dwStartMenuOnSettingChanged);
+
+        StartMenu_UpdatePinnedListHeightFunc = (StartMenu_UpdatePinnedListHeight_t)
+            ((uintptr_t)hStartMenu + dwStartMenuUpdatePinnedListHeight);
+
+        rv = funchook_prepare(
+            funchook,
+            (void**)&StartMenu_OnSettingChangedFunc,
+            StartMenu_OnSettingChangedHook
+        );
+        if (rv != 0)
+        {
+            FreeLibraryAndExitThread(hModule, rv);
+            return rv;
+        }
+
+        rv = funchook_prepare(
+            funchook,
+            (void**)&StartMenu_UpdatePinnedListHeightFunc,
+            StartMenu_UpdatePinnedListHeightHook
         );
         if (rv != 0)
         {

--- a/ExplorerPatcher/dllmain.c
+++ b/ExplorerPatcher/dllmain.c
@@ -11541,7 +11541,7 @@ HKEY hKey_StartUI_TileGrid = NULL;
 /*
  * Fix bug where Recommended section would re-appear.
  *
- *   Various interactions inside the Start Menu would trigger OnSettingChanged(),
+ *   Various interactions inside the Start Menu trigger OnSettingChanged(),
  *   which in turn calls UpdatePinnedListHeight(), which causes the problem.
  *   So hook OnSettingChanged(), mark that it has been called, and, when
  *   UpdatePinnedListHeight() is called afterwards, return from it.
@@ -11570,21 +11570,36 @@ StartMenu_UpdatePinnedListHeightFunc = NULL;
 
 void __fastcall StartMenu_OnSettingChangedHook(void* _this, uintptr_t param_2, void* param_3, void* param_4)
 {
-    // Mark that OnSettingChanged() has ran
-    b_IsFromOnSettingChanged = TRUE;
+    // Mark that OnSettingChanged() has ran, if DisableRecommended is set
+    if (StartDocked_DisableRecommendedSection)
+        b_IsFromOnSettingChanged = TRUE;
     StartMenu_OnSettingChangedFunc(_this, param_2, param_3, param_4);
+
+    /* OnSettingChanged() always returns before UpdatePinnedListHeight() is called.
+     * There is a chance that, in future (or some undocumented Insider) versions
+     * of Windows that do not call UpdatePinnedListHeight() from OnSettingChanged(),
+     * b_IsFromOnSettingChanged will always remain true and _UpdatePinnedListHeight()
+     * will always be skipped, regardless if we want to change Pinned List height or not.
+     * Hence, we will reset variable inside StartMenu_UpdatePinnedListHeightHook(),
+     * and the return will be guarded, so that we force a return only if
+     * StartDocked_DisableRecommendedSection is unset.
+     * 
+     * See LVT_StartDocked_DisableRecommendedSection() for more details.
+    */
 }
 
 void __fastcall StartMenu_UpdatePinnedListHeightHook(void* _this)
 {
-    // If call is coming from OnSettingChanged(), return; 
+    // If call is coming from OnSettingChanged(), reset the trigger variable
+    // and return, if DisableRecommended is set.
     if (b_IsFromOnSettingChanged)
     {
         b_IsFromOnSettingChanged = FALSE;
-        return;
+        if (StartDocked_DisableRecommendedSection)
+            return;
     }
 
-    // Call original function, if call is not coming from OnSettingChanged()
+    // Call original function, if trigger is unset.
     StartMenu_UpdatePinnedListHeightFunc(_this);
 }
 

--- a/ExplorerPatcher/symbols.c
+++ b/ExplorerPatcher/symbols.c
@@ -31,6 +31,10 @@ const char* startdocked_SN[STARTDOCKED_SB_CNT] = {
 const char* startui_SN[STARTUI_SB_CNT] = {
     STARTUI_SB_0,
 };
+const char* startmenu_SN[STARTMENU_SB_CNT] = {
+    STARTMENU_SB_STARTINNERFRAME_ONSETTINGCHANGED,
+    STARTMENU_SB_STARTINNERFRAME_UPDATEPINNEDLISTHEIGHT
+};
 
 const wchar_t DownloadNotificationXML[] =
     L"<toast scenario=\"reminder\" "
@@ -390,6 +394,98 @@ static BOOL ProcessStartUISymbols(char* pszSettingsPath, DWORD* pOffsets)
     return TRUE;
 }
 
+static BOOL ProcessStartMenuSymbols(char* pszSettingsPath, DWORD* pOffsets)
+{
+    HKEY hKey = NULL;
+    DWORD dwDisposition;
+    RegCreateKeyExW(
+        HKEY_CURRENT_USER,
+        TEXT(REGPATH_STARTMENU) L"\\" TEXT(STARTMENU_SB_NAME),
+        0,
+        NULL,
+        REG_OPTION_NON_VOLATILE,
+        KEY_WRITE,
+        NULL,
+        &hKey,
+        &dwDisposition
+    );
+    if (!hKey || hKey == INVALID_HANDLE_VALUE)
+    {
+        printf("[Symbols] Unable to create registry key.\n");
+        return FALSE;
+    }
+
+    WCHAR wszPath[MAX_PATH];
+    ZeroMemory(wszPath, sizeof(wszPath));
+    GetWindowsDirectoryW(wszPath, MAX_PATH);
+    wcscat_s(
+        wszPath,
+        MAX_PATH,
+        L"\\SystemApps\\MicrosoftWindows.Client.Core_cw5n1h2txyewy\\" _T(STARTMENU_SB_NAME) L".dll"
+    );
+
+    if (!FileExistsW(wszPath))
+    {
+        if (hKey) RegCloseKey(hKey);
+        return TRUE; // StartMenu.dll is not present on this installation.
+    }
+
+    char startmenu_sb_dll[MAX_PATH];
+    ZeroMemory(startmenu_sb_dll, sizeof(startmenu_sb_dll));
+    GetWindowsDirectoryA(startmenu_sb_dll, MAX_PATH);
+    strcat_s(startmenu_sb_dll, MAX_PATH,
+        "\\SystemApps\\MicrosoftWindows.Client.Core_cw5n1h2txyewy\\" STARTMENU_SB_NAME ".dll");
+
+    CHAR szHash[100];
+    ZeroMemory(szHash, sizeof(szHash));
+    ComputeFileHash(wszPath, szHash, ARRAYSIZE(szHash));
+
+    printf("[Symbols] Downloading symbols for \"%s\" (\"%s\")...\n",
+        startmenu_sb_dll,
+        szHash
+    );
+
+    if (VnDownloadSymbols(
+        NULL,
+        startmenu_sb_dll,
+        pszSettingsPath,
+        MAX_PATH
+    ))
+    {
+        printf("[Symbols] Symbols for \"%s\" are not available - unable to download.\n", startmenu_sb_dll);
+        printf("[Symbols] Please refer to \"https://github.com/valinet/ExplorerPatcher/wiki/Symbols\" for more information.\n");
+        if (hKey) RegCloseKey(hKey);
+        return FALSE;
+    }
+
+    printf("[Symbols] Reading symbols...\n");
+
+    BOOL bStartMenuSymbolsOk = TRUE;
+
+    if (VnGetSymbols(
+        pszSettingsPath,
+        pOffsets,
+        (char**)startmenu_SN,
+        STARTMENU_SB_CNT
+    ))
+    {
+        printf("[Symbols] Failure in reading symbols for \"%s\".\n", startmenu_sb_dll);
+        if (hKey) RegCloseKey(hKey);
+        return FALSE;
+    }
+
+    RegSetValueExW(hKey, TEXT(STARTMENU_SB_STARTINNERFRAME_ONSETTINGCHANGED), 0, REG_DWORD, (const BYTE*)&pOffsets[0], sizeof(DWORD));
+    RegSetValueExW(hKey, TEXT(STARTMENU_SB_STARTINNERFRAME_UPDATEPINNEDLISTHEIGHT), 0, REG_DWORD, (const BYTE*)&pOffsets[1], sizeof(DWORD));
+
+    RegSetValueExA(hKey, "Hash", 0, REG_SZ, szHash, (DWORD)(strlen(szHash) + 1));
+
+    SaveVersion(hKey, STARTMENU_SB_VERSION);
+
+    if (hKey) RegCloseKey(hKey);
+
+    return TRUE;
+}
+
 DWORD DownloadSymbols(DownloadSymbolsParams* params)
 {
     Sleep(6000);
@@ -546,6 +642,12 @@ DWORD DownloadSymbols(DownloadSymbolsParams* params)
     if (params->loadResult.bNeedToDownloadStartUISymbols && rovi.dwBuildNumber >= 18362)
     {
         BOOL bSuccess = ProcessStartUISymbols(szSettingsPath, symbols_PTRS.startui_PTRS);
+        bAnySuccess |= bSuccess;
+        bAllSuccess &= bSuccess;
+    }
+    if (params->loadResult.bNeedToDownloadStartMenuSymbols && IsWindows11())
+    {
+        BOOL bSuccess = ProcessStartMenuSymbols(szSettingsPath, symbols_PTRS.startmenu_PTRS);
         bAnySuccess |= bSuccess;
         bAllSuccess &= bSuccess;
     }
@@ -840,6 +942,66 @@ LoadSymbolsResult LoadSymbols(symbols_addr* symbols_PTRS)
                HKEY_CURRENT_USER,
                TEXT(REGPATH_STARTMENU) L"\\" TEXT(STARTUI_SB_NAME)
            );
+        }
+    }
+    if (IsWindows11())
+    {
+        // Load StartMenu.dll offsets
+        bOffsetsValid = FALSE;
+        RegCreateKeyExW(
+            HKEY_CURRENT_USER,
+            TEXT(REGPATH_STARTMENU) L"\\" TEXT(STARTMENU_SB_NAME),
+            0,
+            NULL,
+            REG_OPTION_NON_VOLATILE,
+            KEY_READ,
+            NULL,
+            &hKey,
+            &dwDisposition
+        );
+
+        GetWindowsDirectoryW(wszPath, MAX_PATH);
+        wcscat_s(
+            wszPath,
+            MAX_PATH,
+            L"\\SystemApps\\MicrosoftWindows.Client.Core_cw5n1h2txyewy\\"
+            TEXT(STARTMENU_SB_NAME)
+            L".dll"
+        );
+
+        if (ComputeFileHash(wszPath, szHash, ARRAYSIZE(szHash)) == ERROR_SUCCESS)
+        {
+            szStoredHash[0] = 0;
+            dwSize = sizeof(szStoredHash);
+            if (RegQueryValueExA(hKey, "Hash", 0, NULL, szStoredHash, &dwSize) == ERROR_SUCCESS
+                && !_stricmp(szHash, szStoredHash) && CheckVersion(hKey, STARTMENU_SB_VERSION))
+            {
+                dwSize = sizeof(DWORD);
+                RegQueryValueExW(hKey, TEXT(STARTMENU_SB_STARTINNERFRAME_ONSETTINGCHANGED), 0, NULL, (LPBYTE)&symbols_PTRS->startmenu_PTRS[0], &dwSize);
+                RegQueryValueExW(hKey, TEXT(STARTMENU_SB_STARTINNERFRAME_UPDATEPINNEDLISTHEIGHT), 0, NULL, (LPBYTE)&symbols_PTRS->startmenu_PTRS[1], &dwSize);
+
+                bOffsetsValid =
+                    symbols_PTRS->startmenu_PTRS[0] &&
+                    symbols_PTRS->startmenu_PTRS[1];
+            }
+
+            if (!bOffsetsValid)
+            {
+                printf("[Symbols] Symbols for \"%s\" are not available.\n", STARTMENU_SB_NAME);
+#ifdef _M_X64 // TODO Add support for ARM64
+                result.bNeedToDownloadStartMenuSymbols = TRUE;
+#endif
+            }
+        }
+
+        if (hKey) RegCloseKey(hKey);
+
+        if (!bOffsetsValid)
+        {
+            RegDeleteTreeW(
+                HKEY_CURRENT_USER,
+                TEXT(REGPATH_STARTMENU) L"\\" TEXT(STARTMENU_SB_NAME)
+            );
         }
     }
 

--- a/ExplorerPatcher/symbols.h
+++ b/ExplorerPatcher/symbols.h
@@ -48,6 +48,15 @@
 #define STARTUI_SB_CNT 1
 #define STARTUI_SB_VERSION 1
 
+#define STARTMENU_SB_NAME "StartMenu"
+#define STARTMENU_SB_STARTINNERFRAME_ONSETTINGCHANGED \
+    "winrt::StartMenu::implementation::StartInnerFrame::OnSettingChanged"
+#define STARTMENU_SB_STARTINNERFRAME_UPDATEPINNEDLISTHEIGHT \
+    "winrt::StartMenu::implementation::StartInnerFrame::UpdatePinnedListHeight"
+
+#define STARTMENU_SB_CNT 2
+#define STARTMENU_SB_VERSION 1
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -59,6 +68,7 @@ typedef struct symbols_addr
     DWORD twinui_pcshell_PTRS[TWINUI_PCSHELL_SB_CNT];
     DWORD startdocked_PTRS[STARTDOCKED_SB_CNT];
     DWORD startui_PTRS[STARTUI_SB_CNT];
+    DWORD startmenu_PTRS[STARTMENU_SB_CNT];
 } symbols_addr;
 #pragma pack(pop)
 
@@ -69,6 +79,7 @@ typedef struct _LoadSymbolsResult
     BOOL bNeedToDownloadTwinuiPcshellSymbols : 1;
     BOOL bNeedToDownloadStartDockedSymbols : 1;
     BOOL bNeedToDownloadStartUISymbols : 1;
+    BOOL bNeedToDownloadStartMenuSymbols : 1;
 } LoadSymbolsResult;
 
 inline BOOL NeedToDownloadSymbols(const LoadSymbolsResult* pLoadResult)
@@ -76,7 +87,8 @@ inline BOOL NeedToDownloadSymbols(const LoadSymbolsResult* pLoadResult)
     return pLoadResult->bNeedToDownloadExplorerSymbols
         || pLoadResult->bNeedToDownloadTwinuiPcshellSymbols
         || pLoadResult->bNeedToDownloadStartDockedSymbols
-        || pLoadResult->bNeedToDownloadStartUISymbols;
+        || pLoadResult->bNeedToDownloadStartUISymbols
+        || pLoadResult->bNeedToDownloadStartMenuSymbols;
 }
 
 typedef struct _DownloadSymbolsParams


### PR DESCRIPTION
Hello,

Various interactions inside the Start Menu trigger `OnSettingChanged()`, which in turn calls `UpdatePinnedListHeight()`, which causes the reported problem (#4783 #4752 #4509 #4409 #4315 #4072 #3788 #3748 #3313 #2754 #2622 #2580 #2212).
I've hooked `OnSettingChanged()`, to mark that it has been called, forwarded to the real function, and, when `UpdatePinnedListHeight()` is called afterwards (also hooked), we return from the hooked function, if the `DisableRecommended` flag is enabled.

Adjusting Pinned List Height from Settings still works as expected.

Builds that do not have this OnSettingChanged logic will not be affected, functionally. At most, the user might see a notification that only "Some symbols were downloaded".

Fix has been tested and working on:
```
22621.1485 (to see what it does when functions don't exist)

22631.6936

26100.1
26100.1742
26100.2605
26100.4946
26100.6899
26100.8246

26200.8037
```