### PR TITLE
Start10: clear stale HideAppList state during CDS sync

### DIFF
--- a/ExplorerPatcher/StartMenuSettings.cpp
+++ b/ExplorerPatcher/StartMenuSettings.cpp
@@ -128,6 +128,9 @@ extern "C" BOOL NeedsRo_SyncSettingsFromRegToCDS()
         return FALSE;
     }
 
+	// HideAppList
+	start_global_properties->put_HideAppList(FALSE);
+
     DWORD dwValue, dwSize;
 
     // ShowFrequentList


### PR DESCRIPTION
## Summary

On my system, the Windows 10 Start menu showed the application list and pinned tiles as separate views instead of displaying them side by side.

The policy for hiding the application list was not configured. Investigation indicated that the internal CDS `HideAppList` property remained enabled.

Resetting this property while ExplorerPatcher synchronizes the other Start menu CDS properties restored the expected desktop layout on my device.

## Change

Add:

```cpp
start_global_properties->put_HideAppList(FALSE);
```

after creating the `IStartGlobalProperties` object.

This resets the cached CDS state. Policy-based application-list hiding is evaluated separately by the Start menu.

## Testing

Manually tested with:

- Windows 11 25H2, build 26200.9168
- ExplorerPatcher 26100.8457.70.4
- Windows 10 Start menu style
- x64 Release build

Before the change, the application list and pinned tiles appeared as separate views. After installing the modified DLL and restarting `StartMenuExperienceHost`, they appeared side by side.

I have only reproduced and tested this on one device. The issue may depend on a stale persisted state rather than affecting all Windows 11 25H2 installations.

The investigation and patch were prepared with AI assistance. I built and manually verified the resulting binary on my own device. Maintainer review of the undocumented CDS property behavior and the appropriate synchronization behavior would be appreciated.